### PR TITLE
Optimize execution speed

### DIFF
--- a/core/woml-engine/src/durable.rs
+++ b/core/woml-engine/src/durable.rs
@@ -1,4 +1,5 @@
-use std::collections::{BTreeMap, HashSet};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::time::Duration;
 
@@ -14,6 +15,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 pub const RUNTIME_POLICY_QUEUE_CEILING: i64 = 10_000;
+const MAX_ACTIVE_PROJECTION_CACHE_ENTRIES: usize = 256;
 
 use crate::engine::{
   ready_node_ids_for_projection, ready_node_ids_for_projection_at, step_effect_idempotency_key,
@@ -39,7 +41,7 @@ use crate::event::{
 use crate::projection::{
   ApprovalRequestStatus, AttemptStatus, ForEachIterationStatus, ForEachStatus,
   NotificationDeliveryStatus, NotificationMessageUpdateStatus, OperationProjection,
-  ParallelGroupStatus,
+  ParallelGroupStatus, ProjectionFoldState,
 };
 use crate::runtime::RuntimeModuleArtifact;
 use crate::workflow_calls::{
@@ -1447,6 +1449,7 @@ pub enum DurableStoreError {
 #[derive(Debug)]
 pub struct DurableEventStore {
   connection: Connection,
+  projection_cache: RefCell<HashMap<String, ProjectionFoldState>>,
 }
 
 enum RunRecovery {
@@ -2357,7 +2360,10 @@ impl DurableEventStore {
       );
     }
     span.succeed();
-    Ok(Self { connection })
+    Ok(Self {
+      connection,
+      projection_cache: RefCell::new(HashMap::new()),
+    })
   }
 
   pub fn open_in_memory() -> Result<Self, DurableStoreError> {
@@ -2515,7 +2521,10 @@ impl DurableEventStore {
       "DELETE FROM woml_scheduler_claims WHERE expires_at <= ?1",
       [Utc::now().to_rfc3339()],
     )?;
-    Ok(Self { connection })
+    Ok(Self {
+      connection,
+      projection_cache: RefCell::new(HashMap::new()),
+    })
   }
 
   pub fn register_definition(
@@ -4125,6 +4134,8 @@ impl DurableEventStore {
     };
 
     let mut events = load_events(&transaction, &run_id)?;
+    let mut projection_state =
+      projection_state_for_events(&self.projection_cache, &run_id, &events)?;
     let existing_event_count = events.len();
     let workflow = definition_for_run(&transaction, &run_id)?;
     let binding = run_binding_in_transaction(&transaction, &run_id)?;
@@ -4160,7 +4171,7 @@ impl DurableEventStore {
       }
       if iteration.is_none() {
         if let RunEventPayload::BranchSelected(data) = &payload {
-          let projection = fold_events(&events)?;
+          let projection = projection_state.projection();
           if projection.branch_selections.contains_key(&data.branch_id) {
             return Err(DurableStoreError::Contract(format!(
               "Branch {:?} already has an immutable selection.",
@@ -4169,7 +4180,7 @@ impl DurableEventStore {
           }
           let selector_id = format!("__woml_branch__{}__select", data.branch_id);
           let ready =
-            ready_node_ids_for_projection(&workflow, &binding.definition_hash, &projection)
+            ready_node_ids_for_projection(&workflow, &binding.definition_hash, projection)
               .map_err(DurableStoreError::Contract)?;
           if !ready.iter().any(|node_id| node_id == &selector_id) {
             return Err(DurableStoreError::Contract(format!(
@@ -4178,9 +4189,10 @@ impl DurableEventStore {
           }
         }
       }
-      let event = append_to_history_scoped(
+      let event = append_to_history_scoped_incremental(
         &transaction,
         &mut events,
+        &mut projection_state,
         &run_id,
         if index == 0 {
           event_id.clone()
@@ -4196,8 +4208,9 @@ impl DurableEventStore {
     }
     validate_event_history_against_definition(&workflow, &binding.definition_hash, &events)
       .map_err(DurableStoreError::Contract)?;
-    let projection = fold_events(&events)?;
+    let projection = projection_state.projection().clone();
     transaction.commit()?;
+    cache_projection_state(&self.projection_cache, &run_id, projection_state);
     span.count("events", events.len().saturating_sub(existing_event_count));
     span.succeed();
     Ok((first_event.unwrap(), projection))
@@ -4222,6 +4235,8 @@ impl DurableEventStore {
       .transaction_with_behavior(TransactionBehavior::Immediate)?;
     ensure_run_exists(&transaction, run_id)?;
     let mut events = load_events(&transaction, run_id)?;
+    let mut projection_state =
+      projection_state_for_events(&self.projection_cache, run_id, &events)?;
     let event_schema_version = events
       .first()
       .map(|event| event.event_schema_version)
@@ -4249,9 +4264,10 @@ impl DurableEventStore {
       for (index, payload) in translated.into_iter().enumerate() {
         validate_payload_against_definition(&workflow, &binding.definition_hash, &payload)
           .map_err(DurableStoreError::Contract)?;
-        append_to_history(
+        append_to_history_scoped_incremental(
           &transaction,
           &mut events,
+          &mut projection_state,
           run_id,
           if index == 0 {
             event_id.clone()
@@ -4260,14 +4276,16 @@ impl DurableEventStore {
           },
           occurred_at,
           event_schema_version,
+          None,
           payload,
         )?;
       }
     }
     validate_event_history_against_definition(&workflow, &binding.definition_hash, &events)
       .map_err(DurableStoreError::Contract)?;
-    let projection = fold_events(&events)?;
+    let projection = projection_state.projection().clone();
     transaction.commit()?;
+    cache_projection_state(&self.projection_cache, run_id, projection_state);
     span.succeed();
     Ok(projection)
   }
@@ -4293,13 +4311,43 @@ impl DurableEventStore {
   pub fn projection(&self, run_id: &str) -> Result<RunProjection, DurableStoreError> {
     let mut span = crate::performance::PerformanceSpan::new("sqlite", "sqlite.project_run");
     span.run_id(run_id.to_string());
-    let events = self.events(run_id)?;
-    span.count("events", events.len());
     let binding = self.run_binding(run_id)?;
+    let (event_count, last_event_id): (i64, Option<String>) = self.connection.query_row(
+      "SELECT COUNT(*), (
+         SELECT event_id FROM woml_run_events
+         WHERE run_id = ?1 ORDER BY sequence DESC LIMIT 1
+       )
+       FROM woml_run_events WHERE run_id = ?1",
+      [run_id],
+      |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    let event_count = u64::try_from(event_count)
+      .map_err(|_| DurableStoreError::Contract("run event count is invalid".to_string()))?;
+    span.count("events", event_count as usize);
+    if let Some(cached) = self.projection_cache.borrow().get(run_id) {
+      if cached.projection().last_sequence == event_count
+        && cached.last_event_id() == last_event_id.as_deref()
+      {
+        span.count("projection_cache_hits", 1);
+        let mut projection = cached.projection().clone();
+        if projection
+          .event_schema_version
+          .is_some_and(|version| version >= RUN_EVENT_SCHEMA_VERSION_V11)
+          && projection.workflow_id.is_none()
+        {
+          projection.workflow_id = Some(binding.workflow_id);
+        }
+        span.succeed();
+        return Ok(projection);
+      }
+    }
+    span.count("projection_cache_misses", 1);
+    let events = load_events(&self.connection, run_id)?;
     let workflow = self.definition(&binding.definition_hash)?;
     validate_event_history_against_definition(&workflow, &binding.definition_hash, &events)
       .map_err(DurableStoreError::Contract)?;
-    let mut projection = fold_events(&events)?;
+    let state = ProjectionFoldState::from_events(&events)?;
+    let mut projection = state.projection().clone();
     if projection
       .event_schema_version
       .is_some_and(|version| version >= RUN_EVENT_SCHEMA_VERSION_V11)
@@ -4307,6 +4355,7 @@ impl DurableEventStore {
     {
       projection.workflow_id = Some(binding.workflow_id);
     }
+    cache_projection_state(&self.projection_cache, run_id, state);
     span.succeed();
     Ok(projection)
   }
@@ -10000,12 +10049,25 @@ fn write_run_summary(
     return Ok(());
   };
   let projection = fold_events(events)?;
+  write_run_summary_from_projection(
+    connection,
+    first,
+    events.last().unwrap().occurred_at,
+    &projection,
+  )
+}
+
+fn write_run_summary_from_projection(
+  connection: &Connection,
+  first: &RunEvent,
+  updated_at: DateTime<Utc>,
+  projection: &RunProjection,
+) -> Result<(), DurableStoreError> {
   let workflow_id: String = connection.query_row(
     "SELECT workflow_id FROM woml_runs WHERE run_id = ?1",
     [&first.run_id],
     |row| row.get(0),
   )?;
-  let updated_at = events.last().unwrap().occurred_at;
   connection.execute(
     "INSERT INTO woml_run_summaries(
        run_id, workflow_id, status, admitted_at, started_at, updated_at,
@@ -10043,6 +10105,16 @@ fn write_runtime_policy_indexes_for_run(
   else {
     return Ok(());
   };
+  let projection = fold_events(events)?;
+  write_runtime_policy_indexes_from_projection(connection, run_id, admission, &projection)
+}
+
+fn write_runtime_policy_indexes_from_projection(
+  connection: &Connection,
+  run_id: &str,
+  admission: &RunAdmittedData,
+  projection: &RunProjection,
+) -> Result<(), DurableStoreError> {
   let workflow_id: String = connection.query_row(
     "SELECT workflow_id FROM woml_runs WHERE run_id = ?1",
     [run_id],
@@ -10081,7 +10153,6 @@ fn write_runtime_policy_indexes_for_run(
     "DELETE FROM woml_runtime_policy_starts WHERE run_id = ?1",
     [run_id],
   )?;
-  let projection = fold_events(events)?;
   if projection.status == RunStatus::Queued {
     connection.execute(
       "INSERT INTO woml_runtime_policy_queue(
@@ -10138,6 +10209,151 @@ fn rebuild_run_summary_index(connection: &Connection) -> Result<(), DurableStore
     write_run_summary(connection, &events)?;
   }
   Ok(())
+}
+
+fn projection_state_for_events(
+  cache: &RefCell<HashMap<String, ProjectionFoldState>>,
+  run_id: &str,
+  events: &[RunEvent],
+) -> Result<ProjectionFoldState, DurableStoreError> {
+  let cached = cache.borrow_mut().remove(run_id);
+  if let Some(cached) = cached {
+    let sequence_matches = cached.projection().last_sequence == events.len() as u64;
+    let event_matches =
+      cached.last_event_id() == events.last().map(|event| event.event_id.as_str());
+    if sequence_matches && event_matches {
+      return Ok(cached);
+    }
+  }
+  Ok(ProjectionFoldState::from_events(events)?)
+}
+
+fn cache_projection_state(
+  cache: &RefCell<HashMap<String, ProjectionFoldState>>,
+  run_id: &str,
+  state: ProjectionFoldState,
+) {
+  let mut cache = cache.borrow_mut();
+  if matches!(
+    state.projection().status,
+    RunStatus::Succeeded | RunStatus::Failed | RunStatus::Cancelled
+  ) {
+    cache.remove(run_id);
+    return;
+  }
+  if !cache.contains_key(run_id) && cache.len() >= MAX_ACTIVE_PROJECTION_CACHE_ENTRIES {
+    if let Some(evicted) = cache.keys().next().cloned() {
+      cache.remove(&evicted);
+    }
+  }
+  cache.insert(run_id.to_string(), state);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_to_history_scoped_incremental(
+  transaction: &Transaction<'_>,
+  events: &mut Vec<RunEvent>,
+  state: &mut ProjectionFoldState,
+  run_id: &str,
+  event_id: String,
+  occurred_at: DateTime<Utc>,
+  event_schema_version: u32,
+  iteration: Option<crate::event::ForEachIterationScope>,
+  payload: RunEventPayload,
+) -> Result<RunEvent, DurableStoreError> {
+  let payloads = if matches!(
+    event_schema_version,
+    crate::RUN_EVENT_SCHEMA_VERSION_V10
+      | crate::RUN_EVENT_SCHEMA_VERSION_V11
+      | crate::RUN_EVENT_SCHEMA_VERSION_V12
+      | crate::RUN_EVENT_SCHEMA_VERSION_V13
+      | crate::RUN_EVENT_SCHEMA_VERSION_V14
+      | crate::RUN_EVENT_SCHEMA_VERSION_V15
+  ) && matches!(
+    payload,
+    RunEventPayload::RunSucceeded(_) | RunEventPayload::RunFailed(_)
+  ) {
+    expand_model_v11_payload(&definition_for_run(transaction, run_id)?, run_id, payload)?
+  } else {
+    vec![payload]
+  };
+  let mut first = None;
+  for (index, payload) in payloads.into_iter().enumerate() {
+    let event = append_single_to_history_incremental(
+      transaction,
+      events,
+      state,
+      run_id,
+      if index == 0 {
+        event_id.clone()
+      } else {
+        generated_event_id()
+      },
+      occurred_at,
+      event_schema_version,
+      iteration.clone(),
+      payload,
+    )?;
+    first.get_or_insert(event);
+  }
+  Ok(first.unwrap())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_single_to_history_incremental(
+  transaction: &Transaction<'_>,
+  events: &mut Vec<RunEvent>,
+  state: &mut ProjectionFoldState,
+  run_id: &str,
+  event_id: String,
+  occurred_at: DateTime<Utc>,
+  event_schema_version: u32,
+  iteration: Option<crate::event::ForEachIterationScope>,
+  payload: RunEventPayload,
+) -> Result<RunEvent, DurableStoreError> {
+  let sequence = events.len() as u64 + 1;
+  let event = RunEvent {
+    event_schema_version,
+    event_id,
+    run_id: run_id.to_string(),
+    sequence,
+    occurred_at,
+    iteration,
+    payload,
+  };
+  state.apply(&event)?;
+  let event_json = serde_json::to_string(&event)?;
+  let stored_sequence = i64::try_from(sequence).map_err(|_| {
+    DurableStoreError::Contract("event sequence exceeds SQLite integer range".to_string())
+  })?;
+  transaction.execute(
+    "INSERT INTO woml_run_events(
+       run_id, sequence, event_id, event_schema_version, event_json
+     ) VALUES (?1, ?2, ?3, ?4, ?5)",
+    params![
+      run_id,
+      stored_sequence,
+      event.event_id,
+      i64::from(event.event_schema_version),
+      event_json,
+    ],
+  )?;
+  events.push(event.clone());
+  write_run_summary_from_projection(
+    transaction,
+    events.first().unwrap(),
+    event.occurred_at,
+    state.projection(),
+  )?;
+  if let RunEventPayload::RunAdmitted(admission) = &events.first().unwrap().payload {
+    write_runtime_policy_indexes_from_projection(
+      transaction,
+      run_id,
+      admission,
+      state.projection(),
+    )?;
+  }
+  Ok(event)
 }
 
 fn append_to_history(

--- a/core/woml-engine/src/durable.rs
+++ b/core/woml-engine/src/durable.rs
@@ -2579,13 +2579,11 @@ impl DurableEventStore {
     &self,
     definition_hash: &str,
   ) -> Result<CompiledWorkflowDefinition, DurableStoreError> {
-    let model_json: String = self
+    let mut statement = self
       .connection
-      .query_row(
-        "SELECT model_json FROM woml_definitions WHERE definition_hash = ?1",
-        [definition_hash],
-        |row| row.get(0),
-      )
+      .prepare_cached("SELECT model_json FROM woml_definitions WHERE definition_hash = ?1")?;
+    let model_json: String = statement
+      .query_row([definition_hash], |row| row.get(0))
       .optional()?
       .ok_or_else(|| DurableStoreError::DefinitionNotFound(definition_hash.to_string()))?;
     let workflow: CompiledWorkflowDefinition = serde_json::from_str(&model_json)?;
@@ -3466,19 +3464,17 @@ impl DurableEventStore {
   }
 
   pub fn run_binding(&self, run_id: &str) -> Result<RunDefinitionBinding, DurableStoreError> {
-    self
+    let mut statement = self
       .connection
-      .query_row(
-        "SELECT workflow_id, definition_hash FROM woml_runs WHERE run_id = ?1",
-        [run_id],
-        |row| {
-          Ok(RunDefinitionBinding {
-            run_id: run_id.to_string(),
-            workflow_id: row.get(0)?,
-            definition_hash: row.get(1)?,
-          })
-        },
-      )
+      .prepare_cached("SELECT workflow_id, definition_hash FROM woml_runs WHERE run_id = ?1")?;
+    statement
+      .query_row([run_id], |row| {
+        Ok(RunDefinitionBinding {
+          run_id: run_id.to_string(),
+          workflow_id: row.get(0)?,
+          definition_hash: row.get(1)?,
+        })
+      })
       .optional()?
       .ok_or_else(|| DurableStoreError::RunNotFound(run_id.to_string()))
   }
@@ -4299,11 +4295,10 @@ impl DurableEventStore {
   /// Read models use this to reject pathological histories before projection.
   pub fn event_count(&self, run_id: &str) -> Result<usize, DurableStoreError> {
     self.run_binding(run_id)?;
-    let count: i64 = self.connection.query_row(
-      "SELECT COUNT(*) FROM woml_run_events WHERE run_id = ?1",
-      [run_id],
-      |row| row.get(0),
-    )?;
+    let mut statement = self
+      .connection
+      .prepare_cached("SELECT COUNT(*) FROM woml_run_events WHERE run_id = ?1")?;
+    let count: i64 = statement.query_row([run_id], |row| row.get(0))?;
     usize::try_from(count)
       .map_err(|_| DurableStoreError::Contract("run event count is invalid".to_string()))
   }
@@ -4312,15 +4307,15 @@ impl DurableEventStore {
     let mut span = crate::performance::PerformanceSpan::new("sqlite", "sqlite.project_run");
     span.run_id(run_id.to_string());
     let binding = self.run_binding(run_id)?;
-    let (event_count, last_event_id): (i64, Option<String>) = self.connection.query_row(
+    let mut statement = self.connection.prepare_cached(
       "SELECT COUNT(*), (
          SELECT event_id FROM woml_run_events
          WHERE run_id = ?1 ORDER BY sequence DESC LIMIT 1
        )
        FROM woml_run_events WHERE run_id = ?1",
-      [run_id],
-      |row| Ok((row.get(0)?, row.get(1)?)),
     )?;
+    let (event_count, last_event_id): (i64, Option<String>) =
+      statement.query_row([run_id], |row| Ok((row.get(0)?, row.get(1)?)))?;
     let event_count = u64::try_from(event_count)
       .map_err(|_| DurableStoreError::Contract("run event count is invalid".to_string()))?;
     span.count("events", event_count as usize);
@@ -9719,18 +9714,16 @@ fn run_binding_in_transaction(
   connection: &Connection,
   run_id: &str,
 ) -> Result<RunDefinitionBinding, DurableStoreError> {
-  connection
-    .query_row(
-      "SELECT workflow_id, definition_hash FROM woml_runs WHERE run_id = ?1",
-      [run_id],
-      |row| {
-        Ok(RunDefinitionBinding {
-          run_id: run_id.to_string(),
-          workflow_id: row.get(0)?,
-          definition_hash: row.get(1)?,
-        })
-      },
-    )
+  let mut statement = connection
+    .prepare_cached("SELECT workflow_id, definition_hash FROM woml_runs WHERE run_id = ?1")?;
+  statement
+    .query_row([run_id], |row| {
+      Ok(RunDefinitionBinding {
+        run_id: run_id.to_string(),
+        workflow_id: row.get(0)?,
+        definition_hash: row.get(1)?,
+      })
+    })
     .optional()?
     .ok_or_else(|| DurableStoreError::RunNotFound(run_id.to_string()))
 }
@@ -9739,16 +9732,15 @@ fn definition_for_run(
   connection: &Connection,
   run_id: &str,
 ) -> Result<CompiledWorkflowDefinition, DurableStoreError> {
-  let model_json: String = connection
-    .query_row(
-      "SELECT definitions.model_json
-       FROM woml_runs AS runs
-       JOIN woml_definitions AS definitions
-         ON definitions.definition_hash = runs.definition_hash
-       WHERE runs.run_id = ?1",
-      [run_id],
-      |row| row.get(0),
-    )
+  let mut statement = connection.prepare_cached(
+    "SELECT definitions.model_json
+     FROM woml_runs AS runs
+     JOIN woml_definitions AS definitions
+       ON definitions.definition_hash = runs.definition_hash
+     WHERE runs.run_id = ?1",
+  )?;
+  let model_json: String = statement
+    .query_row([run_id], |row| row.get(0))
     .optional()?
     .ok_or_else(|| DurableStoreError::RunNotFound(run_id.to_string()))?;
   let workflow: CompiledWorkflowDefinition = serde_json::from_str(&model_json)?;
@@ -9757,7 +9749,7 @@ fn definition_for_run(
 }
 
 fn load_events(connection: &Connection, run_id: &str) -> Result<Vec<RunEvent>, DurableStoreError> {
-  let mut statement = connection.prepare(
+  let mut statement = connection.prepare_cached(
     "SELECT sequence, event_schema_version, event_json
      FROM woml_run_events WHERE run_id = ?1 ORDER BY sequence",
   )?;

--- a/core/woml-engine/src/durable.rs
+++ b/core/woml-engine/src/durable.rs
@@ -4199,6 +4199,7 @@ impl DurableEventStore {
         event_schema_version,
         iteration.clone(),
         payload,
+        true,
       )?;
       first_event.get_or_insert(event);
     }
@@ -4274,12 +4275,32 @@ impl DurableEventStore {
           event_schema_version,
           None,
           payload,
+          false,
         )?;
       }
     }
     validate_event_history_against_definition(&workflow, &binding.definition_hash, &events)
       .map_err(DurableStoreError::Contract)?;
     let projection = projection_state.projection().clone();
+    let last_occurred_at = events
+      .last()
+      .expect("an atomic event batch preserves a non-empty history")
+      .occurred_at;
+    write_run_summary_from_projection(
+      &transaction,
+      events
+        .first()
+        .expect("an atomic event batch preserves a non-empty history"),
+      last_occurred_at,
+      &projection,
+    )?;
+    if let RunEventPayload::RunAdmitted(admission) = &events
+      .first()
+      .expect("an atomic event batch preserves a non-empty history")
+      .payload
+    {
+      write_runtime_policy_indexes_from_projection(&transaction, run_id, admission, &projection)?;
+    }
     transaction.commit()?;
     cache_projection_state(&self.projection_cache, run_id, projection_state);
     span.succeed();
@@ -10252,6 +10273,7 @@ fn append_to_history_scoped_incremental(
   event_schema_version: u32,
   iteration: Option<crate::event::ForEachIterationScope>,
   payload: RunEventPayload,
+  update_read_models: bool,
 ) -> Result<RunEvent, DurableStoreError> {
   let payloads = if matches!(
     event_schema_version,
@@ -10285,6 +10307,7 @@ fn append_to_history_scoped_incremental(
       event_schema_version,
       iteration.clone(),
       payload,
+      update_read_models,
     )?;
     first.get_or_insert(event);
   }
@@ -10302,6 +10325,7 @@ fn append_single_to_history_incremental(
   event_schema_version: u32,
   iteration: Option<crate::event::ForEachIterationScope>,
   payload: RunEventPayload,
+  update_read_models: bool,
 ) -> Result<RunEvent, DurableStoreError> {
   let sequence = events.len() as u64 + 1;
   let event = RunEvent {
@@ -10331,19 +10355,21 @@ fn append_single_to_history_incremental(
     ],
   )?;
   events.push(event.clone());
-  write_run_summary_from_projection(
-    transaction,
-    events.first().unwrap(),
-    event.occurred_at,
-    state.projection(),
-  )?;
-  if let RunEventPayload::RunAdmitted(admission) = &events.first().unwrap().payload {
-    write_runtime_policy_indexes_from_projection(
+  if update_read_models {
+    write_run_summary_from_projection(
       transaction,
-      run_id,
-      admission,
+      events.first().unwrap(),
+      event.occurred_at,
       state.projection(),
     )?;
+    if let RunEventPayload::RunAdmitted(admission) = &events.first().unwrap().payload {
+      write_runtime_policy_indexes_from_projection(
+        transaction,
+        run_id,
+        admission,
+        state.projection(),
+      )?;
+    }
   }
   Ok(event)
 }

--- a/core/woml-engine/src/projection.rs
+++ b/core/woml-engine/src/projection.rs
@@ -1031,12 +1031,46 @@ pub fn fold_events(events: &[RunEvent]) -> Result<RunProjection, FoldError> {
   result
 }
 
-fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldError> {
-  let mut projection = RunProjection::default();
-  let mut event_ids = HashSet::new();
-  let mut attempt_indexes: HashMap<AttemptIdentity, usize> = HashMap::new();
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ProjectionFoldState {
+  projection: RunProjection,
+  event_ids: HashSet<String>,
+  attempt_indexes: HashMap<AttemptIdentity, usize>,
+  previous_event: Option<RunEvent>,
+}
 
-  for (index, event) in events.iter().enumerate() {
+impl ProjectionFoldState {
+  pub(crate) fn from_events(events: &[RunEvent]) -> Result<Self, FoldError> {
+    let mut state = Self::default();
+    for event in events {
+      state.apply(event)?;
+    }
+    Ok(state)
+  }
+
+  pub(crate) fn projection(&self) -> &RunProjection {
+    &self.projection
+  }
+
+  pub(crate) fn into_projection(self) -> RunProjection {
+    self.projection
+  }
+
+  pub(crate) fn last_event_id(&self) -> Option<&str> {
+    self
+      .previous_event
+      .as_ref()
+      .map(|event| event.event_id.as_str())
+  }
+
+  pub(crate) fn apply(&mut self, event: &RunEvent) -> Result<(), FoldError> {
+    let Self {
+      projection,
+      event_ids,
+      attempt_indexes,
+      previous_event,
+    } = self;
+    let index = projection.last_sequence as usize;
     event.validate()?;
     let expected_sequence = index as u64 + 1;
     if event.sequence != expected_sequence {
@@ -1045,7 +1079,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         event.sequence
       )));
     }
-    if !event_ids.insert(event.event_id.as_str()) {
+    if !event_ids.insert(event.event_id.clone()) {
       return Err(FoldError::InvalidHistory(format!(
         "Event ID {:?} appears more than once.",
         event.event_id
@@ -1084,9 +1118,10 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         | RunEventPayload::ForEachIterationSkipped(_)
     );
     if event.iteration.is_some() && !scoped_loop_event {
-      apply_iteration_scoped_event(&mut projection, event, events.get(index.wrapping_sub(1)))?;
+      apply_iteration_scoped_event(projection, event, previous_event.as_ref())?;
       projection.last_sequence = event.sequence;
-      continue;
+      *previous_event = Some(event.clone());
+      return Ok(());
     }
 
     match &event.payload {
@@ -1148,7 +1183,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         projection.status = RunStatus::Running;
       }
       RunEventPayload::StepAttemptStarted(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if projection
           .attempts
           .iter()
@@ -1224,7 +1259,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         attempt_indexes.insert(key, attempt_index);
       }
       RunEventPayload::StepAttemptSucceeded(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if !projection
           .active_managed_operations(&data.invocation_id)
           .is_empty()
@@ -1263,7 +1298,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
           .insert(data.node_id.clone(), data.output.clone());
       }
       RunEventPayload::StepAttemptFailed(data) => {
-        require_running_or_cancelling(&projection)?;
+        require_running_or_cancelling(projection)?;
         if !projection
           .active_managed_operations(&data.invocation_id)
           .is_empty()
@@ -1292,9 +1327,8 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         };
       }
       RunEventPayload::StepRetryScheduled(data) => {
-        require_running(&projection)?;
-        let previous_event = events.get(index.wrapping_sub(1));
-        let closes_previous_failure = previous_event.is_some_and(|previous| {
+        require_running(projection)?;
+        let closes_previous_failure = previous_event.as_ref().is_some_and(|previous| {
           matches!(
             &previous.payload,
             RunEventPayload::StepAttemptFailed(failed)
@@ -1330,7 +1364,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         );
       }
       RunEventPayload::BranchSelected(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if let Some(selected_arm) = projection.branch_selections.get(&data.branch_id) {
           return Err(FoldError::InvalidHistory(format!(
             "Branch {:?} was already selected as arm {:?}.",
@@ -1342,7 +1376,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
           .insert(data.branch_id.clone(), data.arm_id.clone());
       }
       RunEventPayload::ChoiceSelected(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if projection.choice_selections.contains_key(&data.choice_id) {
           return Err(FoldError::InvalidHistory(format!(
             "Choice {:?} was selected more than once.",
@@ -1354,7 +1388,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
           .insert(data.choice_id.clone(), data.arm_id.clone());
       }
       RunEventPayload::ForkOpened(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if projection.forks.contains_key(&data.fork_id) {
           return Err(FoldError::InvalidHistory(format!(
             "Fork {:?} was opened more than once.",
@@ -1372,7 +1406,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         );
       }
       RunEventPayload::ForkBranchSettled(data) => {
-        require_running_or_cancelling(&projection)?;
+        require_running_or_cancelling(projection)?;
         let fork = projection.forks.get_mut(&data.fork_id).ok_or_else(|| {
           FoldError::InvalidHistory(format!(
             "Fork branch {:?}.{:?} settled before its fork opened.",
@@ -1395,7 +1429,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         );
       }
       RunEventPayload::ForkJoinSettled(data) => {
-        require_running_or_cancelling(&projection)?;
+        require_running_or_cancelling(projection)?;
         let fork = projection.forks.get_mut(&data.fork_id).ok_or_else(|| {
           FoldError::InvalidHistory(format!(
             "Fork {:?} join settled before its fork opened.",
@@ -1433,7 +1467,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         fork.blocking_branch_id = data.blocking_branch_id.clone();
       }
       RunEventPayload::ForEachOpened(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if projection.for_each.contains_key(&data.for_each_id) {
           return Err(FoldError::InvalidHistory(format!(
             "For-each {:?} was opened more than once.",
@@ -1454,7 +1488,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         );
       }
       RunEventPayload::ForEachIterationStarted(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         let scope = event.iteration.as_ref().expect("validated iteration scope");
         let loop_state = projection
           .for_each
@@ -1486,7 +1520,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         );
       }
       RunEventPayload::ForEachIterationSucceeded(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         let scope = event.iteration.as_ref().expect("validated iteration scope");
         if let (Some(result), Some(expected_digest)) = (&data.result, &data.result_digest) {
           if projection_digest(result)? != *expected_digest {
@@ -1517,7 +1551,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         }
       }
       RunEventPayload::ForEachIterationFailed(data) => {
-        require_running_or_cancelling(&projection)?;
+        require_running_or_cancelling(projection)?;
         let scope = event.iteration.as_ref().expect("validated iteration scope");
         let loop_state = projection
           .for_each
@@ -1543,7 +1577,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         }
       }
       RunEventPayload::ForEachIterationSkipped(data) => {
-        require_running_or_cancelling(&projection)?;
+        require_running_or_cancelling(projection)?;
         let scope = event.iteration.as_ref().expect("validated iteration scope");
         let loop_state = projection
           .for_each
@@ -1567,7 +1601,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
       RunEventPayload::ForEachSucceeded(data)
       | RunEventPayload::ForEachFailed(data)
       | RunEventPayload::ForEachCancelled(data) => {
-        require_running_or_cancelling(&projection)?;
+        require_running_or_cancelling(projection)?;
         let is_success = matches!(&event.payload, RunEventPayload::ForEachSucceeded(_));
         let is_cancelled = matches!(&event.payload, RunEventPayload::ForEachCancelled(_));
         let loop_state = projection
@@ -1709,7 +1743,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         }
       }
       RunEventPayload::ParallelGroupStarted(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if projection.parallel_groups.contains_key(&data.parallel_id) {
           return Err(FoldError::InvalidHistory(format!(
             "Parallel group {:?} was started more than once.",
@@ -1726,7 +1760,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         );
       }
       RunEventPayload::ParallelGroupCompleted(data) => {
-        require_running_or_cancelling(&projection)?;
+        require_running_or_cancelling(projection)?;
         let group = projection
           .parallel_groups
           .get_mut(&data.parallel_id)
@@ -1749,7 +1783,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         };
       }
       RunEventPayload::ApprovalRequested(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if projection.approval_requests.contains_key(&data.approval_id) {
           return Err(FoldError::InvalidHistory(format!(
             "Approval {:?} was requested more than once.",
@@ -2118,7 +2152,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         };
       }
       RunEventPayload::OperationStarted(data) => {
-        require_operation_runtime(&projection)?;
+        require_operation_runtime(projection)?;
         let attempt_active = projection.attempts.iter().any(|attempt| {
           attempt.identity.node_id == data.node_id
             && attempt.identity.attempt == data.attempt_number
@@ -2170,9 +2204,9 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         );
       }
       RunEventPayload::OperationSucceeded(data) => {
-        require_operation_runtime(&projection)?;
+        require_operation_runtime(projection)?;
         require_active_operation_attempt(
-          &projection,
+          projection,
           &data.node_id,
           data.attempt_number,
           &data.invocation_id,
@@ -2201,9 +2235,9 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         };
       }
       RunEventPayload::OperationFailed(data) => {
-        require_operation_settlement(&projection)?;
+        require_operation_settlement(projection)?;
         require_active_operation_attempt(
-          &projection,
+          projection,
           &data.node_id,
           data.attempt_number,
           &data.invocation_id,
@@ -2585,7 +2619,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
         };
       }
       RunEventPayload::RunSucceeded(data) => {
-        require_running(&projection)?;
+        require_running(projection)?;
         if projection.operations.values().any(|operation| {
           operation.execution_mode == OperationExecutionMode::Managed
             && operation.status == OperationStatus::Started
@@ -2636,7 +2670,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
             ));
           }
         } else {
-          require_running(&projection)?;
+          require_running(projection)?;
         }
         let failure = match data {
           RunFailedData::V5(RunFailedDataV5::Notification {
@@ -2694,13 +2728,7 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
             if let (Some(node_id), Some(attempt), Some(invocation_id)) =
               (&data.node_id, data.attempt, &data.invocation_id)
             {
-              require_failed_attempt(
-                &projection,
-                &attempt_indexes,
-                node_id,
-                attempt,
-                invocation_id,
-              )?;
+              require_failed_attempt(projection, attempt_indexes, node_id, attempt, invocation_id)?;
             }
             RunFailure::Attempt(data.failure.clone())
           }
@@ -2711,8 +2739,8 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
             failure,
           }) => {
             require_failed_attempt(
-              &projection,
-              &attempt_indexes,
+              projection,
+              attempt_indexes,
               node_id,
               *attempt,
               invocation_id,
@@ -2798,8 +2826,13 @@ fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldErro
       }
     }
     projection.last_sequence = event.sequence;
+    *previous_event = Some(event.clone());
+    Ok(())
   }
-  Ok(projection)
+}
+
+fn fold_events_unprofiled(events: &[RunEvent]) -> Result<RunProjection, FoldError> {
+  ProjectionFoldState::from_events(events).map(ProjectionFoldState::into_projection)
 }
 
 fn projection_digest(value: &Value) -> Result<String, FoldError> {

--- a/core/woml-engine/src/runtime.rs
+++ b/core/woml-engine/src/runtime.rs
@@ -4995,9 +4995,30 @@ async fn continue_runtime_loop<E: RuntimeDagEngine>(
         let source = source.ok_or_else(|| {
           RuntimeExecutionError::Stalled(format!("node {node_id:?} has no script source"))
         })?;
-        let outcome = execute_script_node(engine, run_id, node_id, &source, options, host).await?;
-        let ScriptNodeOutcome::Succeeded(output) = outcome else {
-          continue;
+        let publish_terminal_success = node_id == &terminal_node_id
+          && engine.workflow().graph.settlement.is_none()
+          && reusable_step_descriptor(engine.workflow(), node_id).is_none();
+        let outcome = execute_script_node(
+          engine,
+          run_id,
+          node_id,
+          &source,
+          publish_terminal_success,
+          options,
+          host,
+        )
+        .await?;
+        let output = match outcome {
+          ScriptNodeOutcome::Succeeded(output) => output,
+          ScriptNodeOutcome::WorkflowSucceeded => {
+            execution_order.push(node_id.clone());
+            return Ok(WorkflowRuntimeOutcome::succeeded(final_result(
+              engine,
+              run_id,
+              execution_order.clone(),
+            )?));
+          }
+          ScriptNodeOutcome::RetryScheduled | ScriptNodeOutcome::Cancelled => continue,
         };
         execution_order.push(node_id.clone());
         // In Model v13 this is only the main route's value source. The
@@ -8781,6 +8802,7 @@ async fn execute_script_node<E: RuntimeDagEngine>(
   run_id: &str,
   node_id: &str,
   source: &str,
+  publish_terminal_success: bool,
   options: &RuntimeExecutionOptions,
   host: &mut Option<ScriptHostClient>,
 ) -> Result<ScriptNodeOutcome, RuntimeExecutionError> {
@@ -8986,15 +9008,27 @@ async fn execute_script_node<E: RuntimeDagEngine>(
 
   match outcome {
     HostOutcome::Success { value } => {
-      engine.append_payload(
-        run_id,
-        RunEventPayload::StepAttemptSucceeded(StepAttemptSucceededData {
-          node_id: node_id.to_string(),
-          attempt: attempt_number,
-          invocation_id,
-          output: value.clone(),
-        }),
-      )?;
+      let succeeded = RunEventPayload::StepAttemptSucceeded(StepAttemptSucceededData {
+        node_id: node_id.to_string(),
+        attempt: attempt_number,
+        invocation_id,
+        output: value.clone(),
+      });
+      if publish_terminal_success {
+        engine.append_payloads(
+          run_id,
+          vec![
+            succeeded,
+            RunEventPayload::RunSucceeded(RunSucceededData {
+              terminal_node_id: node_id.to_string(),
+              result: value.clone(),
+            }),
+          ],
+        )?;
+        report_attempt_succeeded(engine, options, run_id, node_id, attempt_number);
+        return Ok(ScriptNodeOutcome::WorkflowSucceeded);
+      }
+      engine.append_payload(run_id, succeeded)?;
       drive_reusable_step_lifecycle(
         engine,
         run_id,
@@ -9027,6 +9061,7 @@ async fn execute_script_node<E: RuntimeDagEngine>(
 
 enum ScriptNodeOutcome {
   Succeeded(Value),
+  WorkflowSucceeded,
   RetryScheduled,
   Cancelled,
 }

--- a/core/woml-engine/src/runtime.rs
+++ b/core/woml-engine/src/runtime.rs
@@ -614,13 +614,16 @@ impl RuntimeExecutionOptions {
     }
   }
 
-  async fn release_policy_execution_slot(&self) -> Result<(), RuntimeExecutionError> {
+  async fn release_policy_execution_slot(
+    &self,
+    store: &mut DurableEventStore,
+  ) -> Result<(), RuntimeExecutionError> {
     let Some(coordinator) = &self.policy_execution else {
       return Ok(());
     };
     let lease = coordinator.lease.lock().await.take();
     if let Some(lease) = lease {
-      lease.release().await?;
+      lease.release(store).await?;
     }
     Ok(())
   }
@@ -967,8 +970,8 @@ pub async fn execute_workflow(
   trigger: Map<String, Value>,
   options: RuntimeExecutionOptions,
 ) -> Result<WorkflowExecutionResult, RuntimeExecutionError> {
-  let engine = InMemoryDagEngine::new(workflow, definition_hash)?;
-  succeeded_execution(execute_with_engine(engine, trigger, options).await?)
+  let mut engine = InMemoryDagEngine::new(workflow, definition_hash)?;
+  succeeded_execution(execute_with_engine(&mut engine, trigger, options).await?)
 }
 
 const POLICY_CLAIM_LEASE: Duration = Duration::from_secs(15);
@@ -1132,12 +1135,11 @@ impl PolicyExecutionLease {
     Ok(())
   }
 
-  async fn release(mut self) -> Result<(), RuntimeExecutionError> {
+  async fn release(mut self, store: &mut DurableEventStore) -> Result<(), RuntimeExecutionError> {
     if let Some(stop) = self.stop.take() {
       let _ = stop.send(());
     }
     let _ = self.heartbeat.await;
-    let mut store = DurableEventStore::open(self.database_path.clone())?;
     let released = store.release_policy_claim(
       &self.claim.run_id,
       &self.claim.owner_id,
@@ -1164,10 +1166,21 @@ async fn acquire_policy_execution_lease(
   run_id: &str,
   options: &RuntimeExecutionOptions,
 ) -> Result<PolicyClaimAcquisition, RuntimeExecutionError> {
+  let mut store = DurableEventStore::open(database_path.to_path_buf())?;
+  acquire_policy_execution_lease_with_store(database_path, run_id, options, &mut store).await
+}
+
+async fn acquire_policy_execution_lease_with_store(
+  database_path: &std::path::Path,
+  run_id: &str,
+  options: &RuntimeExecutionOptions,
+  store: &mut DurableEventStore,
+) -> Result<PolicyClaimAcquisition, RuntimeExecutionError> {
   let mut span =
     crate::performance::PerformanceSpan::new("runtime", "runtime.acquire_policy_lease");
   span.run_id(run_id.to_string());
-  let result = acquire_policy_execution_lease_unprofiled(database_path, run_id, options).await;
+  let result =
+    acquire_policy_execution_lease_unprofiled(database_path, run_id, options, store).await;
   if result.is_ok() {
     span.succeed();
   }
@@ -1178,13 +1191,13 @@ async fn acquire_policy_execution_lease_unprofiled(
   database_path: &std::path::Path,
   run_id: &str,
   options: &RuntimeExecutionOptions,
+  store: &mut DurableEventStore,
 ) -> Result<PolicyClaimAcquisition, RuntimeExecutionError> {
   let owner_id = format!("scheduler_{}", Uuid::new_v4().simple());
   let mut reported_wait = false;
   loop {
     let lease_now = chrono::Utc::now();
     let policy_now = options.clock.now();
-    let mut store = DurableEventStore::open(database_path.to_path_buf())?;
     let rate_eligible_at = match store.try_claim_policy_run_at(
       run_id,
       &owner_id,
@@ -1336,14 +1349,15 @@ async fn finish_timed_out_policy_lifecycle(
   run_id: &str,
   options: RuntimeExecutionOptions,
 ) -> Result<(), RuntimeExecutionError> {
-  let acquisition = acquire_policy_execution_lease(&database_path, run_id, &options).await?;
-  let store = DurableEventStore::open(database_path.clone())?;
+  let mut store = DurableEventStore::open(database_path.clone())?;
+  let acquisition =
+    acquire_policy_execution_lease_with_store(&database_path, run_id, &options, &mut store).await?;
   let binding = store.run_binding(run_id)?;
   let mut options = runtime_modules_from_store(options, &store, &binding.definition_hash)?;
-  let engine = DurableDagEngine::resume(store, run_id)?;
+  let mut engine = DurableDagEngine::resume(store, run_id)?;
   match acquisition {
     PolicyClaimAcquisition::Recovered => {
-      let _ = resume_with_engine(engine, run_id, options).await;
+      let _ = resume_with_engine(&mut engine, run_id, options).await;
     }
     PolicyClaimAcquisition::Claimed(lease) => {
       let coordinator = Arc::new(PolicyExecutionCoordinator {
@@ -1357,8 +1371,9 @@ async fn finish_timed_out_policy_lifecycle(
         .write()
         .await
         .insert(run_id.to_string(), Arc::downgrade(&coordinator));
-      let _ = resume_with_engine(engine, run_id, options.clone()).await;
-      let released = options.release_policy_execution_slot().await;
+      let _ = resume_with_engine(&mut engine, run_id, options.clone()).await;
+      let mut store = engine.into_store();
+      let released = options.release_policy_execution_slot(&mut store).await;
       options
         .policy_execution_registry
         .write()
@@ -1374,10 +1389,11 @@ async fn execute_policy_run_durable(
   database_path: PathBuf,
   run_id: &str,
   options: RuntimeExecutionOptions,
+  store: DurableEventStore,
 ) -> Result<WorkflowRuntimeOutcome, RuntimeExecutionError> {
   let mut span = crate::performance::PerformanceSpan::new("runtime", "runtime.execute_policy_run");
   span.run_id(run_id.to_string());
-  let result = execute_policy_run_durable_unprofiled(database_path, run_id, options).await;
+  let result = execute_policy_run_durable_unprofiled(database_path, run_id, options, store).await;
   if result.is_ok() {
     span.succeed();
   }
@@ -1388,9 +1404,9 @@ async fn execute_policy_run_durable_unprofiled(
   database_path: PathBuf,
   run_id: &str,
   options: RuntimeExecutionOptions,
+  mut store: DurableEventStore,
 ) -> Result<WorkflowRuntimeOutcome, RuntimeExecutionError> {
   {
-    let store = DurableEventStore::open(database_path.clone())?;
     let binding = store.run_binding(run_id)?;
     let workflow = store.definition(&binding.definition_hash)?;
     let policy = workflow.runtime_policy.as_ref().ok_or_else(|| {
@@ -1418,12 +1434,12 @@ async fn execute_policy_run_durable_unprofiled(
     ) {
       let binding = store.run_binding(run_id)?;
       let options = runtime_modules_from_store(options, &store, &binding.definition_hash)?;
-      let engine = DurableDagEngine::resume(store, run_id)?;
-      return resume_with_engine(engine, run_id, options).await;
+      let mut engine = DurableDagEngine::resume(store, run_id)?;
+      return resume_with_engine(&mut engine, run_id, options).await;
     }
   }
-  let acquisition = acquire_policy_execution_lease(&database_path, run_id, &options).await?;
-  let store = DurableEventStore::open(database_path.clone())?;
+  let acquisition =
+    acquire_policy_execution_lease_with_store(&database_path, run_id, &options, &mut store).await?;
   let binding = store.run_binding(run_id)?;
   let mut options = runtime_modules_from_store(options, &store, &binding.definition_hash)?;
   let workflow = store.definition(&binding.definition_hash)?;
@@ -1442,9 +1458,9 @@ async fn execute_policy_run_durable_unprofiled(
       options.clone(),
     );
   }
-  let engine = DurableDagEngine::resume(store, run_id)?;
+  let mut engine = DurableDagEngine::resume(store, run_id)?;
   match acquisition {
-    PolicyClaimAcquisition::Recovered => resume_with_engine(engine, run_id, options).await,
+    PolicyClaimAcquisition::Recovered => resume_with_engine(&mut engine, run_id, options).await,
     PolicyClaimAcquisition::Claimed(lease) => {
       let coordinator = Arc::new(PolicyExecutionCoordinator {
         database_path: database_path.clone(),
@@ -1457,8 +1473,9 @@ async fn execute_policy_run_durable_unprofiled(
         .write()
         .await
         .insert(run_id.to_string(), Arc::downgrade(&coordinator));
-      let outcome = resume_with_engine(engine, run_id, options.clone()).await;
-      let released = options.release_policy_execution_slot().await;
+      let outcome = resume_with_engine(&mut engine, run_id, options.clone()).await;
+      let mut store = engine.into_store();
+      let released = options.release_policy_execution_slot(&mut store).await;
       options
         .policy_execution_registry
         .write()
@@ -1565,8 +1582,7 @@ async fn execute_workflow_durable_internal_unprofiled(
       payload: trigger,
       received_at: options.clock.now(),
     })?;
-    drop(store);
-    return execute_policy_run_durable(database_path, &admission.run_id, options).await;
+    return execute_policy_run_durable(database_path, &admission.run_id, options, store).await;
   }
   store.recover_interrupted_runs()?;
   store.register_definition_module_artifacts(
@@ -1574,8 +1590,8 @@ async fn execute_workflow_durable_internal_unprofiled(
     &definition_hash,
     options.runtime_modules.as_ref(),
   )?;
-  let engine = DurableDagEngine::new(workflow, definition_hash, store)?;
-  execute_with_engine(engine, trigger, options).await
+  let mut engine = DurableDagEngine::new(workflow, definition_hash, store)?;
+  execute_with_engine(&mut engine, trigger, options).await
 }
 
 pub async fn resume_workflow_durable(
@@ -1635,12 +1651,11 @@ async fn execute_admitted_trigger_run_durable_unprofiled(
   let binding = store.run_binding(run_id)?;
   let workflow = store.definition(&binding.definition_hash)?;
   if workflow.schema_version >= crate::COMPILED_MODEL_SCHEMA_VERSION_V12 {
-    drop(store);
-    return execute_policy_run_durable(database_path, run_id, options).await;
+    return execute_policy_run_durable(database_path, run_id, options, store).await;
   }
   let options = runtime_modules_from_store(options, &store, &binding.definition_hash)?;
-  let engine = DurableDagEngine::resume(store, run_id)?;
-  resume_with_engine(engine, run_id, options).await
+  let mut engine = DurableDagEngine::resume(store, run_id)?;
+  resume_with_engine(&mut engine, run_id, options).await
 }
 
 async fn resume_workflow_durable_internal(
@@ -1665,13 +1680,12 @@ async fn resume_workflow_durable_internal(
     ));
   }
   if workflow.schema_version >= crate::COMPILED_MODEL_SCHEMA_VERSION_V12 {
-    drop(store);
-    return execute_policy_run_durable(database_path, run_id, options).await;
+    return execute_policy_run_durable(database_path, run_id, options, store).await;
   }
   store.recover_interrupted_runs()?;
   let options = runtime_modules_from_store(options, &store, &binding.definition_hash)?;
-  let engine = DurableDagEngine::resume(store, run_id)?;
-  resume_with_engine(engine, run_id, options).await
+  let mut engine = DurableDagEngine::resume(store, run_id)?;
+  resume_with_engine(&mut engine, run_id, options).await
 }
 
 fn attach_durable_capability_authority(
@@ -1910,7 +1924,7 @@ pub fn settle_approval_timeout_durable(
 }
 
 async fn execute_with_engine<E: RuntimeDagEngine>(
-  engine: E,
+  engine: &mut E,
   trigger: Map<String, Value>,
   options: RuntimeExecutionOptions,
 ) -> Result<WorkflowRuntimeOutcome, RuntimeExecutionError> {
@@ -1925,7 +1939,7 @@ async fn execute_with_engine<E: RuntimeDagEngine>(
 }
 
 async fn execute_with_engine_unprofiled<E: RuntimeDagEngine>(
-  mut engine: E,
+  engine: &mut E,
   trigger: Map<String, Value>,
   options: RuntimeExecutionOptions,
 ) -> Result<WorkflowRuntimeOutcome, RuntimeExecutionError> {
@@ -1936,7 +1950,7 @@ async fn execute_with_engine_unprofiled<E: RuntimeDagEngine>(
   }
   validate_runtime_modules(engine.workflow(), &options)?;
 
-  execute_runtime(&mut engine, trigger, &options).await
+  execute_runtime(engine, trigger, &options).await
 }
 
 fn sha256_identity(content: &str) -> String {
@@ -2158,7 +2172,7 @@ fn validate_runtime_modules(
 }
 
 async fn resume_with_engine<E: RuntimeDagEngine>(
-  engine: E,
+  engine: &mut E,
   run_id: &str,
   options: RuntimeExecutionOptions,
 ) -> Result<WorkflowRuntimeOutcome, RuntimeExecutionError> {
@@ -2180,7 +2194,7 @@ fn runtime_outcome_run_id(outcome: &WorkflowRuntimeOutcome) -> &str {
 }
 
 async fn resume_with_engine_unprofiled<E: RuntimeDagEngine>(
-  mut engine: E,
+  engine: &mut E,
   run_id: &str,
   options: RuntimeExecutionOptions,
 ) -> Result<WorkflowRuntimeOutcome, RuntimeExecutionError> {
@@ -2195,31 +2209,31 @@ async fn resume_with_engine_unprofiled<E: RuntimeDagEngine>(
   match projection.status {
     RunStatus::Succeeded => {
       return Ok(WorkflowRuntimeOutcome::succeeded(final_result(
-        &engine,
+        engine,
         run_id,
         execution_order,
       )?));
     }
-    RunStatus::Failed => return Err(resumed_failure(&engine, run_id, projection)?),
+    RunStatus::Failed => return Err(resumed_failure(engine, run_id, projection)?),
     RunStatus::Cancelled => {
-      return Err(cancelled_run_error(&engine, run_id)?);
+      return Err(cancelled_run_error(engine, run_id)?);
     }
     RunStatus::Finalizing => {
       let mut host = None;
-      drive_pending_reusable_step_lifecycles(&mut engine, run_id, &options, &mut host).await?;
-      drive_workflow_lifecycle(&mut engine, run_id, &options, &mut host).await?;
+      drive_pending_reusable_step_lifecycles(engine, run_id, &options, &mut host).await?;
+      drive_workflow_lifecycle(engine, run_id, &options, &mut host).await?;
       if let Some(host) = host {
         options.release_script_host(host).await;
       }
       let projection = engine.projection(run_id)?;
       return match projection.status {
         RunStatus::Succeeded => Ok(WorkflowRuntimeOutcome::succeeded(final_result(
-          &engine,
+          engine,
           run_id,
           execution_order,
         )?)),
-        RunStatus::Failed => Err(resumed_failure(&engine, run_id, projection)?),
-        RunStatus::Cancelled => Err(cancelled_run_error(&engine, run_id)?),
+        RunStatus::Failed => Err(resumed_failure(engine, run_id, projection)?),
+        RunStatus::Cancelled => Err(cancelled_run_error(engine, run_id)?),
         _ => Err(RuntimeExecutionError::Stalled(
           "stored run did not finish lifecycle continuation".to_string(),
         )),
@@ -2238,14 +2252,7 @@ async fn resume_with_engine_unprofiled<E: RuntimeDagEngine>(
   let terminal_node_id = runtime_result_node_id(engine.workflow())
     .ok_or_else(|| RuntimeExecutionError::Stalled("no terminal node exists".to_string()))?
     .to_string();
-  continue_runtime(
-    &mut engine,
-    run_id,
-    terminal_node_id,
-    execution_order,
-    &options,
-  )
-  .await
+  continue_runtime(engine, run_id, terminal_node_id, execution_order, &options).await
 }
 
 async fn execute_runtime<E: RuntimeDagEngine>(

--- a/core/woml-engine/src/store.rs
+++ b/core/woml-engine/src/store.rs
@@ -2,7 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use thiserror::Error;
 
-use crate::{fold_events, FoldError, RunEvent, RunProjection};
+use crate::projection::ProjectionFoldState;
+use crate::{FoldError, RunEvent, RunProjection};
 
 #[derive(Debug, Clone, PartialEq, Error)]
 pub enum EventStoreError {
@@ -16,6 +17,7 @@ pub enum EventStoreError {
 pub struct InMemoryEventStore {
   runs: HashMap<String, Vec<RunEvent>>,
   event_ids: HashSet<String>,
+  projections: HashMap<String, ProjectionFoldState>,
 }
 
 impl InMemoryEventStore {
@@ -24,12 +26,21 @@ impl InMemoryEventStore {
       return Err(EventStoreError::DuplicateEventId(event.event_id));
     }
 
-    let mut candidate = self.runs.get(&event.run_id).cloned().unwrap_or_default();
-    candidate.push(event.clone());
-    let projection = fold_events(&candidate)?;
+    let mut candidate = self
+      .projections
+      .get(&event.run_id)
+      .cloned()
+      .unwrap_or_default();
+    candidate.apply(&event)?;
+    let projection = candidate.projection().clone();
 
     self.event_ids.insert(event.event_id.clone());
-    self.runs.insert(event.run_id.clone(), candidate);
+    self
+      .runs
+      .entry(event.run_id.clone())
+      .or_default()
+      .push(event.clone());
+    self.projections.insert(event.run_id, candidate);
     Ok(projection)
   }
 
@@ -38,6 +49,11 @@ impl InMemoryEventStore {
   }
 
   pub fn projection(&self, run_id: &str) -> Result<RunProjection, FoldError> {
-    fold_events(self.events(run_id))
+    Ok(
+      self
+        .projections
+        .get(run_id)
+        .map_or_else(RunProjection::default, |state| state.projection().clone()),
+    )
   }
 }

--- a/core/woml-engine/tests/durable_event_store.rs
+++ b/core/woml-engine/tests/durable_event_store.rs
@@ -227,6 +227,50 @@ fn invalid_append_rolls_back_without_consuming_a_sequence_number() {
 }
 
 #[test]
+fn cached_projection_replays_when_another_store_appends_to_the_run() {
+  let database = TemporaryDatabase::new("projection-cache-refresh");
+  let mut first = DurableEventStore::open(database.path()).unwrap();
+  first
+    .register_definition(&hello_model(), HELLO_HASH)
+    .unwrap();
+  first
+    .start_run(
+      "evt_cache_1",
+      "run_cache_refresh",
+      Utc::now(),
+      "hello",
+      HELLO_HASH,
+      Map::new(),
+    )
+    .unwrap();
+  assert_eq!(
+    first.projection("run_cache_refresh").unwrap().last_sequence,
+    1
+  );
+
+  let mut second = DurableEventStore::open(database.path()).unwrap();
+  second
+    .append_payload(
+      "run_cache_refresh",
+      "evt_cache_2",
+      Utc::now(),
+      RunEventPayload::StepAttemptStarted(StepAttemptStartedData {
+        node_id: "a".to_string(),
+        attempt: 1,
+        invocation_id: "inv_cache_a".to_string(),
+        handler: "runtime.script".to_string(),
+        idempotency_key: None,
+      }),
+    )
+    .unwrap();
+
+  let refreshed = first.projection("run_cache_refresh").unwrap();
+  assert_eq!(refreshed.last_sequence, 2);
+  assert_eq!(refreshed.attempts.len(), 1);
+  assert_eq!(refreshed.attempts[0].identity.invocation_id, "inv_cache_a");
+}
+
+#[test]
 fn run_and_definition_bindings_are_immutable() {
   let mut store = DurableEventStore::open_in_memory().unwrap();
   let workflow = hello_model();

--- a/core/woml-engine/tests/policy_scheduler.rs
+++ b/core/woml-engine/tests/policy_scheduler.rs
@@ -194,7 +194,7 @@ fn shared_queue_skips_an_older_run_blocked_by_its_workflow_limit() {
 #[test]
 fn separate_processes_cannot_oversubscribe_one_workflow() {
   let database = Arc::new(TestDatabase::new());
-  let now = Utc.with_ymd_and_hms(2026, 8, 12, 12, 0, 0).unwrap();
+  let now = Utc::now();
   let hash = "sha256:3333333333333333333333333333333333333333333333333333333333333333";
   let workflow = policy_model("single-slot", 1, "single-slot");
   let (first, second) = {

--- a/core/woml-engine/tests/retry_runtime.rs
+++ b/core/woml-engine/tests/retry_runtime.rs
@@ -290,7 +290,7 @@ async fn non_retryable_timeout_fails_after_the_first_attempt() {
     workflow,
     MODIFIED_HASH.to_string(),
     Map::new(),
-    options(host, 25),
+    options(host, 250),
     database.path().to_path_buf(),
   )
   .await

--- a/woml-cli/src/cli.ts
+++ b/woml-cli/src/cli.ts
@@ -214,6 +214,11 @@ import {
   providerDoctorUsage,
   runProviderDoctor,
 } from './provider-doctor';
+import {
+  readCompiledWorkflowCache,
+  writeCompiledWorkflowCache,
+  type CompiledWorkflowCacheOptions,
+} from './compiled-workflow-cache';
 
 export interface CliIo {
   readonly stdout: (text: string) => void;
@@ -230,6 +235,8 @@ const processIo: CliIo = {
 };
 
 const WOML_CLI_VERSION = packageMetadata.version;
+const COMPILED_WORKFLOW_CACHE_COMPILER_IDENTITY =
+  `woml-cli@${WOML_CLI_VERSION}:cache-v1:model-v16:definition-package-v11`;
 
 class CliInputError extends Error {
   readonly code: string;
@@ -1632,6 +1639,74 @@ async function compileWorkflowSourcesUnprofiled(
       return parseWoml(source, { file: filePath });
     });
     const projectRoot = moduleProjectRoot(filePath);
+    const cacheOptions: CompiledWorkflowCacheOptions = {
+      sourcePath: resolve(filePath),
+      projectRoot: resolve(projectRoot),
+      compilerIdentity: COMPILED_WORKFLOW_CACHE_COMPILER_IDENTITY,
+    };
+    const cached =
+      process.env.WOML_DISABLE_COMPILED_CACHE === '1'
+        ? undefined
+        : await profileAsync(
+            'compiler',
+            'compiler.cache_lookup',
+            async measurements => {
+              const candidate = await readCompiledWorkflowCache(cacheOptions);
+              if (candidate === undefined) {
+                if (measurements !== undefined) measurements.counts.misses = 1;
+                return undefined;
+              }
+              try {
+                if (
+                  compiledDefinitionHash(candidate.workflow) !==
+                  candidate.definitionHash
+                ) {
+                  if (measurements !== undefined) measurements.counts.misses = 1;
+                  return undefined;
+                }
+              } catch {
+                if (measurements !== undefined) measurements.counts.misses = 1;
+                return undefined;
+              }
+              if (measurements !== undefined) {
+                measurements.counts.hits = 1;
+                measurements.counts.sources = candidate.sourceSnapshot.length;
+                measurements.counts.modules = candidate.runtimeModules.length;
+              }
+              return candidate;
+            }
+          );
+    if (cached !== undefined) {
+      if (io !== undefined && cached.reusableEditorData !== undefined) {
+        await profileAsync(
+          'compiler',
+          'compiler.refresh_reusable_editor_data',
+          async measurements => {
+            if (measurements !== undefined) {
+              measurements.bytes.output = Buffer.byteLength(
+                cached.reusableEditorData!
+              );
+            }
+            await refreshReusableEditorData(
+              filePath,
+              cached.reusableEditorData!,
+              io
+            );
+          }
+        );
+      }
+      compiled.push({
+        filePath,
+        activationInputPaths: [resolve(filePath)],
+        document,
+        workflow: cached.workflow,
+        definitionHash: cached.definitionHash,
+        runtimeModules: cached.runtimeModules,
+        sourceSnapshot: cached.sourceSnapshot,
+        migrationDiagnostics: cached.migrationDiagnostics,
+      });
+      continue;
+    }
     const reusableGraph = profileSync('compiler', 'compiler.resolve_reusable_graph', measurements => {
       const graph = resolveWomlReusableDefinitionGraph(document, {
         sourcePath: filePath,
@@ -1660,6 +1735,10 @@ async function compileWorkflowSourcesUnprofiled(
       if (skipReusableDefinitions) continue;
       assertWomlDocumentRunnable(document);
     }
+    const reusableEditorData =
+      reusableGraph.definitions.length === 0
+        ? undefined
+        : generateWomlReusableCustomData(reusableGraph);
     if (reusableGraph.definitions.length > 0) {
       if (io !== undefined) {
         await profileAsync('compiler', 'compiler.validate_module_entrypoints', async measurements => {
@@ -1672,9 +1751,10 @@ async function compileWorkflowSourcesUnprofiled(
           validateResolvedReusableWorkflow(document, reusableGraph)
         );
         await profileAsync('compiler', 'compiler.refresh_reusable_editor_data', async measurements => {
-          const content = generateWomlReusableCustomData(reusableGraph);
-          if (measurements !== undefined) measurements.bytes.output = Buffer.byteLength(content);
-          await refreshReusableEditorData(filePath, content, io);
+          if (measurements !== undefined) {
+            measurements.bytes.output = Buffer.byteLength(reusableEditorData!);
+          }
+          await refreshReusableEditorData(filePath, reusableEditorData!, io);
         });
       }
     }
@@ -1796,7 +1876,7 @@ async function compileWorkflowSourcesUnprofiled(
           }
           return modules;
         });
-    compiled.push({
+    const compiledSource: CompiledWorkflowSource = {
       filePath,
       activationInputPaths: [resolve(filePath)],
       document,
@@ -1811,7 +1891,31 @@ async function compileWorkflowSourcesUnprofiled(
         reusableGraph.definitions.length === 0
           ? inspectWomlMigrationDiagnostics(document)
           : reusableCommunicationAliasDiagnostics(document, reusableGraph),
-    });
+    };
+    compiled.push(compiledSource);
+    if (process.env.WOML_DISABLE_COMPILED_CACHE !== '1') {
+      await profileAsync(
+        'compiler',
+        'compiler.cache_store',
+        async measurements => {
+          const stored = await writeCompiledWorkflowCache(cacheOptions, {
+            workflow: compiledSource.workflow,
+            definitionHash: compiledSource.definitionHash,
+            runtimeModules: compiledSource.runtimeModules,
+            sourceSnapshot: compiledSource.sourceSnapshot,
+            migrationDiagnostics: compiledSource.migrationDiagnostics,
+            ...(reusableEditorData === undefined
+              ? {}
+              : { reusableEditorData }),
+          });
+          if (measurements !== undefined) {
+            measurements.counts.stored = stored ? 1 : 0;
+            measurements.counts.sources = compiledSource.sourceSnapshot.length;
+            measurements.counts.modules = compiledSource.runtimeModules.length;
+          }
+        }
+      );
+    }
   }
   const workflowIds = new Set<string>();
   for (const item of compiled) {
@@ -1955,7 +2059,7 @@ async function compileWorkflowInputsUnprofiled(
   return compiled.map(source => ({ ...source, activationInputPaths }));
 }
 
-async function compileWorkflowInputs(
+export async function compileWorkflowInputs(
   inputPaths: readonly string[],
   io?: CliIo
 ): Promise<readonly CompiledWorkflowSource[]> {

--- a/woml-cli/src/cli.ts
+++ b/woml-cli/src/cli.ts
@@ -219,6 +219,7 @@ import {
   writeCompiledWorkflowCache,
   type CompiledWorkflowCacheOptions,
 } from './compiled-workflow-cache';
+import { runtimeActivationRequirements } from './runtime-activation';
 
 export interface CliIo {
   readonly stdout: (text: string) => void;
@@ -4149,6 +4150,29 @@ async function activateWorkflows(
           );
         }
       );
+      const activationRequirements = profileSync(
+        'runtime',
+        'runtime.resolve_activation_requirements',
+        measurements => {
+          const requirements = runtimeActivationRequirements(
+            productionSources.map(source => source.workflow)
+          );
+          if (measurements !== undefined) {
+            measurements.counts.provider_hosts =
+              Number(requirements.triggerHandlers.includes('trigger.slack')) +
+              Number(requirements.providers.telegram.inbound) +
+              Number(requirements.providers.discord.inbound);
+            measurements.counts.public_http = Number(requirements.publicHttp);
+            measurements.counts.script_execution = Number(
+              requirements.scriptExecution
+            );
+            measurements.counts.runtime_modules = Number(
+              requirements.runtimeModules
+            );
+          }
+          return requirements;
+        }
+      );
       const routes = productionSources.flatMap(source =>
         webhookRouteSummaries(source.workflow)
       );
@@ -4161,36 +4185,14 @@ async function activateWorkflows(
       const discordRegistrations = productionSources.flatMap(source =>
         discordTriggerRegistrations(source.workflow, source.definitionHash)
       );
-      const telegramPollingCredentials = [
-        ...new Set(
-          productionSources.flatMap(source =>
-            source.workflow.schemaVersion === 15
-              ? source.workflow.communication.providers.flatMap(provider =>
-                  provider.provider === 'telegram' &&
-                  (provider.triggerIds.length > 0 ||
-                    provider.notificationDeliveryIds.length > 0)
-                    ? provider.credentialNames
-                    : []
-                )
-              : []
-          )
-        ),
-      ];
-      const discordGatewayCredentials = [
-        ...new Set(
-          productionSources.flatMap(source =>
-            source.workflow.schemaVersion === 15
-              ? source.workflow.communication.providers.flatMap(provider =>
-                  provider.provider === 'discord' &&
-                  (provider.triggerIds.length > 0 ||
-                    provider.notificationDeliveryIds.length > 0)
-                    ? provider.credentialNames
-                    : []
-                )
-              : []
-          )
-        ),
-      ];
+      const telegramPollingCredentials = activationRequirements.providers
+        .telegram.inbound
+        ? activationRequirements.providers.telegram.inboundCredentialNames
+        : [];
+      const discordGatewayCredentials = activationRequirements.providers
+        .discord.inbound
+        ? activationRequirements.providers.discord.inboundCredentialNames
+        : [];
       const uniqueEventRoutes: EventRouteSummary[] = [];
       const seenEventNames = new Set<string>();
       for (const route of eventRoutes) {
@@ -4210,14 +4212,13 @@ async function activateWorkflows(
         }
         seenRoutes.set(route.path, route);
       }
-      const hasWhatsAppEndpoint = productionSources.some(source =>
-        source.workflow.schemaVersion === 15 &&
-        source.workflow.communication.providers.some(
-          provider => provider.provider === 'whatsapp'
-        )
-      );
+      const hasWhatsAppEndpoint =
+        activationRequirements.providers.whatsapp.inbound;
       const hasHttpEndpoint =
-        routes.length > 0 || uniqueEventRoutes.length > 0 || hasWhatsAppEndpoint;
+        activationRequirements.publicHttp ||
+        routes.length > 0 ||
+        uniqueEventRoutes.length > 0 ||
+        hasWhatsAppEndpoint;
       const currentActivationId = activationIdentity(productionSources);
       const currentDeploymentId = deploymentIdentity(args.statePath);
       const runtime = await profileAsync(

--- a/woml-cli/src/compiled-workflow-cache.ts
+++ b/woml-cli/src/compiled-workflow-cache.ts
@@ -1,0 +1,373 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  stat,
+  unlink,
+} from 'node:fs/promises';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+import {
+  inspectCompiledWorkflowGraph,
+  type CompiledWorkflowDefinition,
+  type WomlAdvisoryDiagnostic,
+} from '@woml/compiler';
+
+import type { RustRuntimeModuleArtifact } from './rust-executor';
+
+const CACHE_PROFILE = 'woml.compiled-workflow-cache/v1' as const;
+const CACHE_VERSION = 1 as const;
+const MAX_CACHE_BYTES = 32 * 1024 * 1024;
+const MAX_SOURCES = 4_096;
+const MAX_MODULES = 256;
+const DIGEST = /^sha256:[0-9a-f]{64}$/u;
+
+export interface CompiledWorkflowCacheArtifact {
+  readonly workflow: CompiledWorkflowDefinition;
+  readonly definitionHash: string;
+  readonly runtimeModules: readonly RustRuntimeModuleArtifact[];
+  readonly sourceSnapshot: readonly {
+    readonly path: string;
+    readonly digest: string;
+  }[];
+  readonly migrationDiagnostics: readonly WomlAdvisoryDiagnostic[];
+  readonly reusableEditorData?: string;
+}
+
+interface CacheEnvelope {
+  readonly profile: typeof CACHE_PROFILE;
+  readonly cacheVersion: typeof CACHE_VERSION;
+  readonly compilerIdentity: string;
+  readonly sourcePath: string;
+  readonly projectRoot: string;
+  readonly artifactDigest: string;
+  readonly artifact: CompiledWorkflowCacheArtifact;
+}
+
+export interface CompiledWorkflowCacheOptions {
+  readonly sourcePath: string;
+  readonly projectRoot: string;
+  readonly compilerIdentity: string;
+}
+
+function digest(value: string | Uint8Array): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function canonicalize(value: unknown): string {
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'string'
+  ) {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('Non-finite cache number.');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const record = value as Readonly<Record<string, unknown>>;
+    return `{${Object.keys(record)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${canonicalize(record[key])}`)
+      .join(',')}}`;
+  }
+  throw new TypeError('Compiled cache artifacts must contain strict JSON.');
+}
+
+function object(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function insideProject(path: string, projectRoot: string): boolean {
+  const location = relative(projectRoot, path);
+  return (
+    location === '' ||
+    (location !== '..' && !location.startsWith(`..${sep}`) && !isAbsolute(location))
+  );
+}
+
+function sourceSnapshot(
+  value: unknown,
+  sourcePath: string,
+  projectRoot: string
+): CompiledWorkflowCacheArtifact['sourceSnapshot'] | undefined {
+  if (!Array.isArray(value) || value.length < 1 || value.length > MAX_SOURCES) {
+    return undefined;
+  }
+  const seen = new Set<string>();
+  const sources: Array<{ path: string; digest: string }> = [];
+  for (const item of value) {
+    if (!object(item) || Object.keys(item).sort().join(',') !== 'digest,path') {
+      return undefined;
+    }
+    if (
+      typeof item.path !== 'string' ||
+      resolve(item.path) !== item.path ||
+      !insideProject(item.path, projectRoot) ||
+      typeof item.digest !== 'string' ||
+      !DIGEST.test(item.digest) ||
+      seen.has(item.path)
+    ) {
+      return undefined;
+    }
+    seen.add(item.path);
+    sources.push({ path: item.path, digest: item.digest });
+  }
+  return seen.has(sourcePath) ? sources : undefined;
+}
+
+function runtimeModules(
+  value: unknown
+): readonly RustRuntimeModuleArtifact[] | undefined {
+  if (!Array.isArray(value) || value.length > MAX_MODULES) return undefined;
+  const names = new Set<string>();
+  const modules: RustRuntimeModuleArtifact[] = [];
+  for (const item of value) {
+    if (
+      !object(item) ||
+      Object.keys(item).sort().join(',') !==
+        'bundle,bundleDigest,exports,name,sourceMap,sourceMapDigest' ||
+      typeof item.name !== 'string' ||
+      item.name.length < 1 ||
+      item.name.length > 128 ||
+      names.has(item.name) ||
+      typeof item.bundle !== 'string' ||
+      typeof item.sourceMap !== 'string' ||
+      typeof item.bundleDigest !== 'string' ||
+      typeof item.sourceMapDigest !== 'string' ||
+      !DIGEST.test(item.bundleDigest) ||
+      !DIGEST.test(item.sourceMapDigest) ||
+      digest(item.bundle) !== item.bundleDigest ||
+      digest(item.sourceMap) !== item.sourceMapDigest ||
+      !Array.isArray(item.exports) ||
+      item.exports.some(
+        exported =>
+          typeof exported !== 'string' ||
+          exported.length < 1 ||
+          exported.length > 256
+      ) ||
+      new Set(item.exports).size !== item.exports.length
+    ) {
+      return undefined;
+    }
+    names.add(item.name);
+    modules.push({
+      name: item.name,
+      bundleDigest: item.bundleDigest,
+      sourceMapDigest: item.sourceMapDigest,
+      exports: item.exports,
+      bundle: item.bundle,
+      sourceMap: item.sourceMap,
+    });
+  }
+  return modules;
+}
+
+function position(value: unknown): boolean {
+  return (
+    object(value) &&
+    Object.keys(value).sort().join(',') === 'column,line,offset' &&
+    Number.isSafeInteger(value.line) &&
+    Number(value.line) >= 1 &&
+    Number.isSafeInteger(value.column) &&
+    Number(value.column) >= 1 &&
+    Number.isSafeInteger(value.offset) &&
+    Number(value.offset) >= 0
+  );
+}
+
+function diagnostics(value: unknown): readonly WomlAdvisoryDiagnostic[] | undefined {
+  if (!Array.isArray(value) || value.length > 4_096) return undefined;
+  const decoded: WomlAdvisoryDiagnostic[] = [];
+  for (const item of value) {
+    if (
+      !object(item) ||
+      item.severity !== 'warning' ||
+      typeof item.code !== 'string' ||
+      typeof item.phase !== 'string' ||
+      !['parse', 'validation', 'compile', 'runtime'].includes(item.phase) ||
+      typeof item.message !== 'string' ||
+      typeof item.file !== 'string' ||
+      !object(item.location) ||
+      !position(item.location.start) ||
+      !position(item.location.end) ||
+      (item.hint !== undefined && typeof item.hint !== 'string')
+    ) {
+      return undefined;
+    }
+    decoded.push(item as unknown as WomlAdvisoryDiagnostic);
+  }
+  return decoded;
+}
+
+function decodeArtifact(
+  value: unknown,
+  options: CompiledWorkflowCacheOptions
+): CompiledWorkflowCacheArtifact | undefined {
+  if (
+    !object(value) ||
+    !object(value.workflow) ||
+    !Number.isSafeInteger(value.workflow.schemaVersion) ||
+    Number(value.workflow.schemaVersion) < 1 ||
+    Number(value.workflow.schemaVersion) > 16 ||
+    typeof value.workflow.workflowId !== 'string' ||
+    !object(value.workflow.graph) ||
+    !Array.isArray(value.workflow.graph.nodes) ||
+    !Array.isArray(value.workflow.graph.edges) ||
+    !Array.isArray(value.workflow.graph.entryNodeIds) ||
+    typeof value.definitionHash !== 'string' ||
+    !DIGEST.test(value.definitionHash) ||
+    (value.reusableEditorData !== undefined &&
+      typeof value.reusableEditorData !== 'string')
+  ) {
+    return undefined;
+  }
+  const sources = sourceSnapshot(
+    value.sourceSnapshot,
+    options.sourcePath,
+    options.projectRoot
+  );
+  const modules = runtimeModules(value.runtimeModules);
+  const warnings = diagnostics(value.migrationDiagnostics);
+  if (sources === undefined || modules === undefined || warnings === undefined) {
+    return undefined;
+  }
+  const workflow = value.workflow as unknown as CompiledWorkflowDefinition;
+  try {
+    if (inspectCompiledWorkflowGraph(workflow.graph).length > 0) return undefined;
+  } catch {
+    return undefined;
+  }
+  return {
+    workflow,
+    definitionHash: value.definitionHash,
+    runtimeModules: modules,
+    sourceSnapshot: sources,
+    migrationDiagnostics: warnings,
+    ...(value.reusableEditorData === undefined
+      ? {}
+      : { reusableEditorData: value.reusableEditorData }),
+  };
+}
+
+export function compiledWorkflowCachePath(
+  options: CompiledWorkflowCacheOptions
+): string {
+  const sourceIdentity = createHash('sha256')
+    .update(resolve(options.sourcePath))
+    .digest('hex');
+  return join(
+    resolve(options.projectRoot),
+    '.woml',
+    'cache',
+    'compiled-v1',
+    `${sourceIdentity}.json`
+  );
+}
+
+export async function readCompiledWorkflowCache(
+  options: CompiledWorkflowCacheOptions
+): Promise<CompiledWorkflowCacheArtifact | undefined> {
+  try {
+    const path = compiledWorkflowCachePath(options);
+    const metadata = await stat(path);
+    if (!metadata.isFile() || metadata.size < 2 || metadata.size > MAX_CACHE_BYTES) {
+      return undefined;
+    }
+    const raw = await readFile(path, 'utf8');
+    const decoded: unknown = JSON.parse(raw);
+    if (
+      !object(decoded) ||
+      decoded.profile !== CACHE_PROFILE ||
+      decoded.cacheVersion !== CACHE_VERSION ||
+      decoded.compilerIdentity !== options.compilerIdentity ||
+      decoded.sourcePath !== resolve(options.sourcePath) ||
+      decoded.projectRoot !== resolve(options.projectRoot) ||
+      typeof decoded.artifactDigest !== 'string' ||
+      !DIGEST.test(decoded.artifactDigest) ||
+      !Object.hasOwn(decoded, 'artifact') ||
+      digest(canonicalize(decoded.artifact)) !== decoded.artifactDigest
+    ) {
+      return undefined;
+    }
+    const artifact = decodeArtifact(decoded.artifact, {
+      ...options,
+      sourcePath: resolve(options.sourcePath),
+      projectRoot: resolve(options.projectRoot),
+    });
+    if (artifact === undefined) return undefined;
+    for (const source of artifact.sourceSnapshot) {
+      if (digest(await readFile(source.path)) !== source.digest) return undefined;
+    }
+    return artifact;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function writeCompiledWorkflowCache(
+  options: CompiledWorkflowCacheOptions,
+  artifact: CompiledWorkflowCacheArtifact
+): Promise<boolean> {
+  const sourcePath = resolve(options.sourcePath);
+  const projectRoot = resolve(options.projectRoot);
+  const path = compiledWorkflowCachePath({ ...options, sourcePath, projectRoot });
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  let temporaryCreated = false;
+  try {
+    const normalized = decodeArtifact(artifact, {
+      ...options,
+      sourcePath,
+      projectRoot,
+    });
+    if (normalized === undefined) return false;
+    const envelope: CacheEnvelope = {
+      profile: CACHE_PROFILE,
+      cacheVersion: CACHE_VERSION,
+      compilerIdentity: options.compilerIdentity,
+      sourcePath,
+      projectRoot,
+      artifactDigest: digest(canonicalize(normalized)),
+      artifact: normalized,
+    };
+    const content = `${JSON.stringify(envelope)}\n`;
+    if (Buffer.byteLength(content) > MAX_CACHE_BYTES) return false;
+    await mkdir(join(projectRoot, '.woml', 'cache', 'compiled-v1'), {
+      recursive: true,
+      mode: 0o700,
+    });
+    const file = await open(temporaryPath, 'wx', 0o600);
+    temporaryCreated = true;
+    try {
+      await file.writeFile(content, 'utf8');
+    } finally {
+      await file.close();
+    }
+    try {
+      await rename(temporaryPath, path);
+    } catch (error) {
+      if (
+        !(error instanceof Error &&
+          'code' in error &&
+          (error.code === 'EEXIST' || error.code === 'EPERM'))
+      ) {
+        throw error;
+      }
+      await unlink(path).catch(() => undefined);
+      await rename(temporaryPath, path);
+    }
+    temporaryCreated = false;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (temporaryCreated) await unlink(temporaryPath).catch(() => undefined);
+  }
+}

--- a/woml-cli/src/performance-profiler.ts
+++ b/woml-cli/src/performance-profiler.ts
@@ -1,7 +1,3 @@
-import { randomUUID } from 'node:crypto';
-import { appendFile, mkdir } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
-
 export type PerformanceProcessV1 =
   | 'cli'
   | 'native'
@@ -46,6 +42,7 @@ interface PerformanceSpanV1 {
 
 interface ProfilerState {
   readonly outputPath: string;
+  readonly workingDirectory: string;
   readonly traceId: string;
   readonly process: PerformanceProcessV1;
   readonly spans: PerformanceSpanV1[];
@@ -74,9 +71,10 @@ function configuredState(): ProfilerState | undefined {
   const traceId =
     configuredTrace !== undefined && /^[A-Za-z0-9_.:-]{1,128}$/u.test(configuredTrace)
       ? configuredTrace
-      : `trace_${randomUUID().replaceAll('-', '')}`;
+      : `trace_${crypto.randomUUID().replaceAll('-', '')}`;
   return {
-    outputPath: resolve(output),
+    outputPath: output,
+    workingDirectory: process.cwd(),
     traceId,
     process: processName,
     spans: [],
@@ -197,9 +195,14 @@ export async function profileAsync<T>(
 export async function flushPerformanceProfile(): Promise<void> {
   if (state === undefined || state.writtenSpans >= state.spans.length) return;
   const unwritten = state.spans.slice(state.writtenSpans);
-  await mkdir(dirname(state.outputPath), { recursive: true });
+  const [{ appendFile, mkdir }, { dirname, resolve }] = await Promise.all([
+    import('node:fs/promises'),
+    import('node:path'),
+  ]);
+  const outputPath = resolve(state.workingDirectory, state.outputPath);
+  await mkdir(dirname(outputPath), { recursive: true });
   await appendFile(
-    state.outputPath,
+    outputPath,
     `${unwritten.map(span => JSON.stringify(span)).join('\n')}\n`,
     { encoding: 'utf8', mode: 0o600 }
   );

--- a/woml-cli/src/runtime-activation.ts
+++ b/woml-cli/src/runtime-activation.ts
@@ -1,0 +1,243 @@
+import type {
+  CompiledWorkflowDefinition,
+  CompiledWorkflowNode,
+  ValueExpression,
+} from '@woml/compiler';
+
+export const RUNTIME_ACTIVATION_REQUIREMENTS_PROFILE =
+  'woml.runtime-activation-requirements/v1' as const;
+
+export type BuiltInCommunicationProvider = 'telegram' | 'discord' | 'whatsapp';
+
+export interface ProviderActivationRequirementV1 {
+  readonly provider: BuiltInCommunicationProvider;
+  readonly used: boolean;
+  /** An inbound connection is required for triggers or approval decisions. */
+  readonly inbound: boolean;
+  readonly triggerIds: readonly string[];
+  readonly approvalDeliveryIds: readonly string[];
+  readonly notificationDeliveryIds: readonly string[];
+  readonly messaging: boolean;
+  readonly credentialNames: readonly string[];
+  readonly inboundCredentialNames: readonly string[];
+}
+
+export interface RuntimeActivationRequirementsV1 {
+  readonly profile: typeof RUNTIME_ACTIVATION_REQUIREMENTS_PROFILE;
+  readonly triggerHandlers: readonly string[];
+  readonly publicHttp: boolean;
+  readonly scriptExecution: boolean;
+  readonly runtimeModules: boolean;
+  readonly providers: Readonly<
+    Record<BuiltInCommunicationProvider, ProviderActivationRequirementV1>
+  >;
+}
+
+interface CommunicationRequirement {
+  readonly provider: BuiltInCommunicationProvider;
+  readonly triggerIds: readonly string[];
+  readonly notificationDeliveryIds: readonly string[];
+  readonly messaging: boolean;
+  readonly credentialNames: readonly string[];
+}
+
+function communicationRequirements(
+  workflow: CompiledWorkflowDefinition
+): readonly CommunicationRequirement[] {
+  if (!('communication' in workflow) || workflow.communication === undefined)
+    return [];
+  return workflow.communication.providers;
+}
+
+function workflowNodes(
+  workflow: CompiledWorkflowDefinition
+): readonly CompiledWorkflowNode[] {
+  return [
+    ...workflow.graph.nodes,
+    ...(workflow.schemaVersion === 16
+      ? workflow.graph.forEach.flatMap(descriptor => descriptor.body.nodes)
+      : []),
+  ];
+}
+
+function literalString(
+  expression: ValueExpression | undefined
+): string | undefined {
+  return expression?.kind === 'literal' && typeof expression.value === 'string'
+    ? expression.value
+    : undefined;
+}
+
+function collectSecretNames(
+  expression: ValueExpression | undefined,
+  names: Set<string>
+): void {
+  if (expression === undefined) return;
+  if (expression.kind === 'secretReference') {
+    names.add(expression.name);
+    return;
+  }
+  if (expression.kind === 'array') {
+    for (const item of expression.items) collectSecretNames(item, names);
+    return;
+  }
+  if (expression.kind === 'object') {
+    for (const value of Object.values(expression.fields))
+      collectSecretNames(value, names);
+  }
+}
+
+function inboundCredentialNames(
+  provider: BuiltInCommunicationProvider,
+  workflow: CompiledWorkflowDefinition
+): readonly string[] {
+  const names = new Set<string>();
+  for (const trigger of workflow.triggers) {
+    if (trigger.handler === `trigger.${provider}`)
+      collectSecretNames(trigger.config, names);
+  }
+  for (const node of workflowNodes(workflow)) {
+    if (
+      node.handler !== 'engine.approval-wait' ||
+      node.inputs.kind !== 'object'
+    )
+      continue;
+    const notifications = node.inputs.fields.notifications;
+    if (notifications?.kind !== 'array') continue;
+    for (const notification of notifications.items) {
+      if (
+        notification.kind === 'object' &&
+        literalString(notification.fields.provider) === provider
+      ) {
+        collectSecretNames(notification.fields.credentials, names);
+      }
+    }
+  }
+  return [...names];
+}
+
+function approvalDeliveries(
+  workflow: CompiledWorkflowDefinition
+): ReadonlyMap<BuiltInCommunicationProvider, ReadonlySet<string>> {
+  const deliveries = new Map<BuiltInCommunicationProvider, Set<string>>();
+  for (const node of workflowNodes(workflow)) {
+    if (
+      node.handler !== 'engine.approval-wait' ||
+      node.inputs.kind !== 'object'
+    )
+      continue;
+    const notifications = node.inputs.fields.notifications;
+    if (notifications?.kind !== 'array') continue;
+    for (const notification of notifications.items) {
+      if (notification.kind !== 'object') continue;
+      const provider = literalString(notification.fields.provider);
+      const deliveryId = literalString(notification.fields.deliveryId);
+      if (
+        deliveryId === undefined ||
+        (provider !== 'telegram' &&
+          provider !== 'discord' &&
+          provider !== 'whatsapp')
+      ) {
+        continue;
+      }
+      const providerDeliveries = deliveries.get(provider) ?? new Set<string>();
+      providerDeliveries.add(deliveryId);
+      deliveries.set(provider, providerDeliveries);
+    }
+  }
+  return deliveries;
+}
+
+function providerRequirement(
+  provider: BuiltInCommunicationProvider,
+  workflows: readonly CompiledWorkflowDefinition[]
+): ProviderActivationRequirementV1 {
+  const triggerIds = new Set<string>();
+  const notificationDeliveryIds = new Set<string>();
+  const approvalDeliveryIds = new Set<string>();
+  const credentialNames = new Set<string>();
+  const inboundCredentials = new Set<string>();
+  let messaging = false;
+
+  for (const workflow of workflows) {
+    for (const requirement of communicationRequirements(workflow)) {
+      if (requirement.provider !== provider) continue;
+      for (const triggerId of requirement.triggerIds) triggerIds.add(triggerId);
+      for (const deliveryId of requirement.notificationDeliveryIds)
+        notificationDeliveryIds.add(deliveryId);
+      for (const credentialName of requirement.credentialNames)
+        credentialNames.add(credentialName);
+      messaging ||= requirement.messaging;
+    }
+    for (const deliveryId of approvalDeliveries(workflow).get(provider) ?? [])
+      approvalDeliveryIds.add(deliveryId);
+    for (const credentialName of inboundCredentialNames(provider, workflow))
+      inboundCredentials.add(credentialName);
+  }
+
+  const sortedTriggerIds = [...triggerIds].sort();
+  const sortedApprovalDeliveryIds = [...approvalDeliveryIds].sort();
+  const sortedNotificationDeliveryIds = [...notificationDeliveryIds].sort();
+  return {
+    provider,
+    used:
+      sortedTriggerIds.length > 0 ||
+      sortedNotificationDeliveryIds.length > 0 ||
+      messaging,
+    inbound:
+      sortedTriggerIds.length > 0 || sortedApprovalDeliveryIds.length > 0,
+    triggerIds: sortedTriggerIds,
+    approvalDeliveryIds: sortedApprovalDeliveryIds,
+    notificationDeliveryIds: sortedNotificationDeliveryIds,
+    messaging,
+    credentialNames: [...credentialNames].sort(),
+    inboundCredentialNames: [...inboundCredentials].sort(),
+  };
+}
+
+/**
+ * Derives optional runtime infrastructure only from frozen compiled models.
+ * The result is order-independent so loading the same workflow set in a
+ * different CLI order cannot change which listeners or provider hosts start.
+ */
+export function runtimeActivationRequirements(
+  workflows: readonly CompiledWorkflowDefinition[]
+): RuntimeActivationRequirementsV1 {
+  const triggerHandlers = [
+    ...new Set(
+      workflows.flatMap(workflow =>
+        workflow.triggers.map(trigger => trigger.handler)
+      )
+    ),
+  ].sort();
+  const telegram = providerRequirement('telegram', workflows);
+  const discord = providerRequirement('discord', workflows);
+  const whatsapp = providerRequirement('whatsapp', workflows);
+  const nodes = workflows.flatMap(workflow => workflowNodes(workflow));
+  const lifecycleActions = workflows.flatMap(workflow =>
+    'lifecycle' in workflow && workflow.lifecycle !== undefined
+      ? workflow.lifecycle.hooks.flatMap(hook => hook.actions)
+      : []
+  );
+
+  return {
+    profile: RUNTIME_ACTIVATION_REQUIREMENTS_PROFILE,
+    triggerHandlers,
+    publicHttp:
+      triggerHandlers.some(handler =>
+        ['trigger.webhook', 'trigger.event'].includes(handler)
+      ) || whatsapp.inbound,
+    scriptExecution:
+      nodes.some(node => node.handler === 'runtime.script') ||
+      lifecycleActions.some(
+        action => action.handler === 'runtime.lifecycle-script'
+      ),
+    runtimeModules: workflows.some(
+      workflow =>
+        'moduleRuntime' in workflow &&
+        workflow.moduleRuntime !== undefined &&
+        workflow.moduleRuntime.modules.length > 0
+    ),
+    providers: { telegram, discord, whatsapp },
+  };
+}

--- a/woml-cli/tests/cli.test.ts
+++ b/woml-cli/tests/cli.test.ts
@@ -1054,7 +1054,7 @@ describe('woml test one-shot compatibility', () => {
         join(
           consumerDirectory,
           'node_modules',
-          'woml',
+          'woml-cli',
           'dist',
           'notification-provider-host.js'
         )
@@ -1065,7 +1065,7 @@ describe('woml test one-shot compatibility', () => {
         join(
           consumerDirectory,
           'node_modules',
-          'woml',
+          'woml-cli',
           'slack',
           'manifest.json'
         )

--- a/woml-cli/tests/compiled-workflow-cache.test.ts
+++ b/woml-cli/tests/compiled-workflow-cache.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { compileWoml, parseWoml } from '@woml/compiler';
+
+import {
+  compiledWorkflowCachePath,
+  readCompiledWorkflowCache,
+  writeCompiledWorkflowCache,
+  type CompiledWorkflowCacheArtifact,
+  type CompiledWorkflowCacheOptions,
+} from '../src/compiled-workflow-cache';
+import { compileWorkflowInputs } from '../src/cli';
+import { compiledDefinitionHash } from '../src/rust-executor';
+
+function digest(value: string): string {
+  return `sha256:${new Bun.CryptoHasher('sha256')
+    .update(value)
+    .digest('hex')}`;
+}
+
+function simpleWorkflow(id = 'cached-workflow'): string {
+  return `<woml>
+  <workflow id="${id}" name="Cached workflow" version="1.0.0">
+    <triggers><manual id="start" /></triggers>
+    <steps><step id="done"><script>return { ok: true };</script></step></steps>
+  </workflow>
+</woml>`;
+}
+
+function cacheFixture(root: string): {
+  readonly sourcePath: string;
+  readonly options: CompiledWorkflowCacheOptions;
+  readonly artifact: CompiledWorkflowCacheArtifact;
+} {
+  const sourcePath = join(root, 'workflow.woml');
+  const source = simpleWorkflow();
+  writeFileSync(sourcePath, source);
+  const workflow = compileWoml(parseWoml(source, { file: sourcePath }));
+  return {
+    sourcePath,
+    options: {
+      sourcePath,
+      projectRoot: root,
+      compilerIdentity: 'test-compiler-v1',
+    },
+    artifact: {
+      workflow,
+      definitionHash: compiledDefinitionHash(workflow),
+      runtimeModules: [],
+      sourceSnapshot: [{ path: sourcePath, digest: digest(source) }],
+      migrationDiagnostics: [],
+    },
+  };
+}
+
+describe('compiled workflow cache', () => {
+  test('round-trips a validated artifact through an atomic private cache file', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'woml-compiled-cache-'));
+    try {
+      const fixture = cacheFixture(root);
+      expect(
+        await writeCompiledWorkflowCache(fixture.options, fixture.artifact)
+      ).toBe(true);
+      expect(await readCompiledWorkflowCache(fixture.options)).toEqual(
+        fixture.artifact
+      );
+      if (process.platform !== 'win32') {
+        expect(
+          statSync(compiledWorkflowCachePath(fixture.options)).mode & 0o777
+        ).toBe(0o600);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('turns source, compiler, and corrupted-artifact changes into safe misses', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'woml-compiled-cache-'));
+    try {
+      const fixture = cacheFixture(root);
+      expect(
+        await writeCompiledWorkflowCache(fixture.options, fixture.artifact)
+      ).toBe(true);
+
+      writeFileSync(fixture.sourcePath, `${simpleWorkflow()}\n`);
+      expect(await readCompiledWorkflowCache(fixture.options)).toBeUndefined();
+      writeFileSync(fixture.sourcePath, simpleWorkflow());
+      expect(
+        await readCompiledWorkflowCache({
+          ...fixture.options,
+          compilerIdentity: 'different-compiler',
+        })
+      ).toBeUndefined();
+
+      const path = compiledWorkflowCachePath(fixture.options);
+      const envelope = JSON.parse(readFileSync(path, 'utf8'));
+      envelope.artifact.workflow.workflowId = 'tampered';
+      writeFileSync(path, JSON.stringify(envelope));
+      expect(await readCompiledWorkflowCache(fixture.options)).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('reuses module artifacts and invalidates them when imported code changes', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'woml-compiled-cache-module-'));
+    try {
+      const sourcePath = join(root, 'workflow.woml');
+      const modulePath = join(root, 'math.ts');
+      writeFileSync(join(root, 'package.json'), '{"private":true}\n');
+      writeFileSync(
+        sourcePath,
+        `<woml>
+  <imports><module name="math" from="./math.ts" /></imports>
+  <workflow id="module-cache" name="Module cache" version="1.0.0">
+    <triggers><manual id="start" /></triggers>
+    <steps><step id="calculate"><script>return { value: services.math.value() };</script></step></steps>
+  </workflow>
+</woml>`
+      );
+      writeFileSync(modulePath, 'export function value() { return 1; }\n');
+
+      const first = await compileWorkflowInputs([sourcePath]);
+      expect(first[0]?.runtimeModules).toHaveLength(1);
+      const cacheFiles = join(root, '.woml', 'cache', 'compiled-v1');
+      const cachePath = join(
+        cacheFiles,
+        `${new Bun.CryptoHasher('sha256').update(sourcePath).digest('hex')}.json`
+      );
+      const firstCache = readFileSync(cachePath, 'utf8');
+
+      const second = await compileWorkflowInputs([sourcePath]);
+      expect(second[0]?.definitionHash).toBe(first[0]?.definitionHash);
+      expect(second[0]?.runtimeModules).toEqual(first[0]?.runtimeModules);
+      expect(readFileSync(cachePath, 'utf8')).toBe(firstCache);
+
+      writeFileSync(modulePath, 'export function value() { return 2; }\n');
+      const changed = await compileWorkflowInputs([sourcePath]);
+      expect(changed[0]?.definitionHash).not.toBe(first[0]?.definitionHash);
+      expect(changed[0]?.runtimeModules[0]?.bundleDigest).not.toBe(
+        first[0]?.runtimeModules[0]?.bundleDigest
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('caches imported WOML definitions and invalidates their lowered model', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'woml-compiled-cache-reusable-'));
+    try {
+      const sourcePath = join(root, 'workflow.woml');
+      const reusablePath = join(root, 'prepare.woml');
+      writeFileSync(join(root, 'package.json'), '{"private":true}\n');
+      writeFileSync(
+        sourcePath,
+        `<woml>
+  <imports><module name="prepare" from="./prepare.woml" /></imports>
+  <workflow id="reusable-cache" name="Reusable cache" version="1.0.0">
+    <triggers><manual id="start" /></triggers>
+    <steps><prepare id="prepared" value="hello" /></steps>
+  </workflow>
+</woml>`
+      );
+      const reusable = (changed: boolean): string => `<woml>
+  <props><prop name="value" required="true" /></props>
+  <step name="Prepare"><script>return { value: props.value, changed: ${changed} };</script></step>
+</woml>`;
+      writeFileSync(reusablePath, reusable(false));
+
+      const first = await compileWorkflowInputs([sourcePath]);
+      expect(first[0]?.runtimeModules.length).toBeGreaterThan(0);
+      const cachePath = compiledWorkflowCachePath({
+        sourcePath,
+        projectRoot: root,
+        compilerIdentity: 'path-only',
+      });
+      const cachedEnvelope = JSON.parse(readFileSync(cachePath, 'utf8'));
+      expect(cachedEnvelope.artifact.reusableEditorData).toContain('prepare');
+      const second = await compileWorkflowInputs([sourcePath]);
+      expect(second[0]?.definitionHash).toBe(first[0]?.definitionHash);
+
+      writeFileSync(reusablePath, reusable(true));
+      const changed = await compileWorkflowInputs([sourcePath]);
+      expect(changed[0]?.definitionHash).not.toBe(first[0]?.definitionHash);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/woml-cli/tests/performance-measurement.test.ts
+++ b/woml-cli/tests/performance-measurement.test.ts
@@ -45,6 +45,24 @@ const regressionBudgets = decodePerformanceRegressionBudgets(
 const builtTest = existsSync(nativeCore) ? test : test.skip;
 
 describe('performance measurement contract v1', () => {
+  test('keeps disabled worker profiling free of eager diagnostic dependencies', () => {
+    const source = readFileSync(
+      resolve(projectRoot, 'woml-cli/src/performance-profiler.ts'),
+      'utf8'
+    );
+    const flushStart = source.indexOf(
+      'export async function flushPerformanceProfile'
+    );
+    expect(flushStart).toBeGreaterThan(0);
+    const bootstrap = source.slice(0, flushStart);
+    const flush = source.slice(flushStart);
+    expect(bootstrap).not.toContain("from 'node:crypto'");
+    expect(bootstrap).not.toContain("from 'node:fs/promises'");
+    expect(bootstrap).not.toContain("from 'node:path'");
+    expect(flush).toContain("import('node:fs/promises')");
+    expect(flush).toContain("import('node:path')");
+  });
+
   test('summarizes raw samples without hiding their distribution', () => {
     expect(summarizeSamples([4, 1, 3, 2])).toEqual({
       count: 4,

--- a/woml-cli/tests/performance-measurement.test.ts
+++ b/woml-cli/tests/performance-measurement.test.ts
@@ -226,6 +226,10 @@ describe('performance measurement contract v1', () => {
           ],
           {
             cwd: resolve(projectRoot, 'woml-cli'),
+            env: {
+              ...process.env,
+              WOML_DISABLE_COMPILED_CACHE: '1',
+            },
             stdout: 'pipe',
             stderr: 'pipe',
             timeout: 60_000,

--- a/woml-cli/tests/runtime-activation.test.ts
+++ b/woml-cli/tests/runtime-activation.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  compileWoml,
+  parseWoml,
+  type CompiledWorkflowDefinition,
+} from '@woml/compiler';
+
+import { runtimeActivationRequirements } from '../src/runtime-activation';
+
+function compile(source: string, name: string): CompiledWorkflowDefinition {
+  return compileWoml(parseWoml(source, { file: `${name}.woml` }));
+}
+
+const simple = compile(
+  `
+<woml>
+  <workflow id="simple" name="Simple" version="1.0.0">
+    <triggers><manual id="start" /></triggers>
+    <steps>
+      <step id="hello"><script>return { message: 'hello' };</script></step>
+    </steps>
+  </workflow>
+</woml>`,
+  'simple'
+);
+
+function telegramLifecycle(): CompiledWorkflowDefinition {
+  return compile(
+    `
+<woml>
+  <workflow id="telegram-lifecycle" name="Telegram lifecycle" version="1.0.0">
+    <triggers><manual id="start" /></triggers>
+    <steps>
+      <step id="hello"><script>return { message: 'hello' };</script></step>
+    </steps>
+    <lifecycle>
+      <on-complete>
+        <notify>
+          <telegram chats="123456" message="Done" bot-token="{{secrets.TELEGRAM_BOT_TOKEN}}" />
+        </notify>
+      </on-complete>
+    </lifecycle>
+  </workflow>
+</woml>`,
+    'telegram-lifecycle'
+  );
+}
+
+function telegramApproval(): CompiledWorkflowDefinition {
+  return compile(
+    `
+<woml>
+  <workflow id="telegram-approval" name="Telegram approval" version="1.0.0">
+    <triggers><manual id="start" /></triggers>
+    <steps>
+      <approval id="review" timeout="1h" on-timeout="reject">
+        <notify>
+          <telegram chats="123456" bot-token="{{secrets.TELEGRAM_BOT_TOKEN}}" />
+        </notify>
+        <when-approved>
+          <step id="approved"><script>return { approved: true };</script></step>
+        </when-approved>
+        <when-rejected>
+          <step id="rejected"><script>return { approved: false };</script></step>
+        </when-rejected>
+      </approval>
+    </steps>
+  </workflow>
+</woml>`,
+    'telegram-approval'
+  );
+}
+
+function forEachTelegramLifecycle(): CompiledWorkflowDefinition {
+  return compile(
+    `
+<woml>
+  <workflow id="for-each-notification" name="For each notification" version="1.0.0">
+    <triggers><manual id="start" /></triggers>
+    <steps>
+      <step id="seed"><script>return { items: [1] };</script></step>
+      <for-each id="items" items="{{context.steps.seed.items}}">
+        <step id="visit"><script>return { item: context.item };</script></step>
+      </for-each>
+    </steps>
+    <lifecycle>
+      <on-complete>
+        <notify>
+          <telegram chats="123456" message="Done" bot-token="{{secrets.TELEGRAM_BOT_TOKEN}}" />
+        </notify>
+      </on-complete>
+    </lifecycle>
+  </workflow>
+</woml>`,
+    'for-each-notification'
+  );
+}
+
+function discordTriggerAndNotification(): CompiledWorkflowDefinition {
+  return compile(
+    `
+<woml>
+  <workflow id="discord-mixed" name="Discord mixed" version="1.0.0">
+    <triggers>
+      <discord id="message" events="app-mention" bot-token="{{secrets.DISCORD_TRIGGER_TOKEN}}" />
+    </triggers>
+    <steps>
+      <step id="reply"><script>return { message: context.payload.text };</script></step>
+    </steps>
+    <lifecycle>
+      <on-complete>
+        <notify>
+          <discord channels="200000000000000001" message="Done" bot-token="{{secrets.DISCORD_NOTIFY_TOKEN}}" />
+        </notify>
+      </on-complete>
+    </lifecycle>
+  </workflow>
+</woml>`,
+    'discord-mixed'
+  );
+}
+
+describe('compiled-model runtime activation requirements', () => {
+  test('keeps a simple manual workflow free of optional ingress and providers', () => {
+    expect(runtimeActivationRequirements([simple])).toEqual({
+      profile: 'woml.runtime-activation-requirements/v1',
+      triggerHandlers: ['trigger.manual'],
+      publicHttp: false,
+      scriptExecution: true,
+      runtimeModules: false,
+      providers: {
+        telegram: {
+          provider: 'telegram',
+          used: false,
+          inbound: false,
+          triggerIds: [],
+          approvalDeliveryIds: [],
+          notificationDeliveryIds: [],
+          messaging: false,
+          credentialNames: [],
+          inboundCredentialNames: [],
+        },
+        discord: {
+          provider: 'discord',
+          used: false,
+          inbound: false,
+          triggerIds: [],
+          approvalDeliveryIds: [],
+          notificationDeliveryIds: [],
+          messaging: false,
+          credentialNames: [],
+          inboundCredentialNames: [],
+        },
+        whatsapp: {
+          provider: 'whatsapp',
+          used: false,
+          inbound: false,
+          triggerIds: [],
+          approvalDeliveryIds: [],
+          notificationDeliveryIds: [],
+          messaging: false,
+          credentialNames: [],
+          inboundCredentialNames: [],
+        },
+      },
+    });
+  });
+
+  test('does not start Telegram polling for an outbound-only lifecycle notification', () => {
+    const requirement = runtimeActivationRequirements([telegramLifecycle()]);
+    expect(requirement.providers.telegram).toMatchObject({
+      used: true,
+      inbound: false,
+      triggerIds: [],
+      approvalDeliveryIds: [],
+      credentialNames: ['TELEGRAM_BOT_TOKEN'],
+      inboundCredentialNames: [],
+    });
+    expect(requirement.providers.telegram.notificationDeliveryIds).toHaveLength(
+      1
+    );
+  });
+
+  test('starts Telegram inbound handling when approval buttons can return a decision', () => {
+    const requirement = runtimeActivationRequirements([telegramApproval()]);
+    expect(requirement.providers.telegram).toMatchObject({
+      used: true,
+      inbound: true,
+      triggerIds: [],
+      credentialNames: ['TELEGRAM_BOT_TOKEN'],
+      inboundCredentialNames: ['TELEGRAM_BOT_TOKEN'],
+    });
+    expect(requirement.providers.telegram.approvalDeliveryIds).toHaveLength(1);
+  });
+
+  test('preserves provider requirements on Model v16 for-each workflows', () => {
+    const workflow = forEachTelegramLifecycle();
+    expect(workflow.schemaVersion).toBe(16);
+    expect(
+      runtimeActivationRequirements([workflow]).providers.telegram
+    ).toMatchObject({
+      used: true,
+      inbound: false,
+      credentialNames: ['TELEGRAM_BOT_TOKEN'],
+      inboundCredentialNames: [],
+    });
+  });
+
+  test('opens only credentials that belong to an inbound provider surface', () => {
+    const requirement = runtimeActivationRequirements([
+      discordTriggerAndNotification(),
+    ]).providers.discord;
+    expect(requirement).toMatchObject({
+      used: true,
+      inbound: true,
+      triggerIds: ['message'],
+      credentialNames: ['DISCORD_NOTIFY_TOKEN', 'DISCORD_TRIGGER_TOKEN'],
+      inboundCredentialNames: ['DISCORD_TRIGGER_TOKEN'],
+    });
+  });
+
+  test('merges multiple workflow requirements deterministically', () => {
+    const first = runtimeActivationRequirements([simple, telegramApproval()]);
+    const reversed = runtimeActivationRequirements([
+      telegramApproval(),
+      simple,
+    ]);
+    expect(reversed).toEqual(first);
+  });
+});


### PR DESCRIPTION
# Performance Optimization

## Summary

This PR completes WOML's first performance optimization cycle. It improves workflow execution, persistence, worker startup, compilation, and idle runtime usage without weakening durability or script isolation.

## What changed

### Incremental event projection

Active runs no longer rebuild their complete state from the full event history after every event. The runtime incrementally advances the in-memory projection while the durable event log remains authoritative.

### Persistent durable-store sessions

A workflow run now reuses its SQLite session and prepared statements across definition lookup, policy admission, execution, and finalization. Independent connections remain where concurrent work requires them.

### Safe event batching

Related events that represent one atomic transition are persisted in a single SQLite transaction. Externally observable boundaries—including script invocation, retries, capabilities, approvals, and cancellation—remain separate.

### Faster isolated workers

Fresh Bun workers are still created for every script invocation, but unnecessary profiler and Node module initialization was removed from the normal execution path. Script globals and secrets remain isolated between invocations.

### Compiled workflow caching

Validated compiled workflows are cached under `.woml/cache/compiled-v1/`.

A cache hit requires matching content hashes for:

- The root `.woml` file
- Imported WOML files
- Imported JavaScript and TypeScript modules
- Compiler and CLI identity

Corrupt, stale, oversized, or missing cache entries safely fall back to normal compilation.

### Lazy runtime activation

WOML now derives a deterministic, versioned activation manifest from the compiled workflows.

Optional infrastructure starts only when required:

- Telegram and Discord inbound hosts start for triggers and interactive approvals.
- Outbound-only notifications do not keep polling or gateway connections alive.
- WhatsApp callback HTTP starts only for triggers and approvals.
- Only credentials required by inbound provider surfaces are activated.
- Model v16, `<for-each>`, and multi-workflow activation are supported.

Core durability, administration, workflow-call routing, and observability remain available.

## Performance results

Measured with 30 iterations and 5 warm-ups:

| Workflow | baseline | After | Improvement |
| --- | ---: | ---: | ---: |
| Two-step workflow | 110.54 ms | 66.95 ms | 39.4% faster |
| Eight-step workflow | 282.71 ms | 190.45 ms | 32.6% faster |

The latest eight-step result also recorded a `229.18 ms` p95, showing more consistent execution under repeated runs.

## Safety guarantees preserved

- The durable event log remains authoritative.
- Every script invocation still receives a fresh isolated worker.
- Crash recovery and interrupted-attempt behavior are unchanged.
- Retry and idempotency boundaries remain durable.
- Approval, cancellation, and workflow-call behavior remain intact.
- Compilation caches cannot bypass compiled-model validation.
- Optional services are activated from frozen compiled models, not source-level guesses.

## Verification

- Rust engine regression tests passed.
- Script-host isolation and capability tests passed.
- Compiled-cache tests passed.
- Manual trigger and communication-provider tests passed.
- Model v16 and multi-workflow activation tests passed.
- TypeScript typechecking passed.
- Release-shaped JavaScript build passed.
